### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/audiobooker/scrappers/__init__.py
+++ b/audiobooker/scrappers/__init__.py
@@ -1,7 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
 from threading import Thread
-from fuzzywuzzy import process
+from rapidfuzz import process
 from audiobooker.exceptions import UnknownAuthorIdException, \
     UnknownBookIdException, ScrappingError, UnknownGenreIdException, \
     UnknownAuthorException, UnknownBookException, UnknownGenreException

--- a/audiobooker/scrappers/kiddie_records.py
+++ b/audiobooker/scrappers/kiddie_records.py
@@ -5,7 +5,7 @@ from audiobooker.exceptions import UnknownAuthorIdException, \
 from audiobooker import AudioBook
 from audiobooker.scrappers import AudioBookSource
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 class KiddieAudioBook(AudioBook):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 bs4
 feedparser
-fuzzywuzzy
+rapidfuzz

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='audiobooker',
     version='0.2.6',
     packages=['audiobooker', 'audiobooker.scrappers', 'audiobooker.utils'],
-    install_requires=["requests", "bs4", "feedparser", "fuzzywuzzy"],
+    install_requires=["requests", "bs4", "feedparser", "rapidfuzz"],
     url='https://github.com/OpenJarbas/audiobooker',
     license='MIT',
     author='jarbasAI',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy