### PR TITLE
feat: BookIndex — persistent SQLite index with offline search and YouTube follow

### DIFF
--- a/audiobooker/__init__.py
+++ b/audiobooker/__init__.py
@@ -9,6 +9,7 @@ from audiobooker.search import (
     search_by_narrator, search_by_tag, ALL_SOURCES,
 )
 from audiobooker.utils import check_url_availability, score_book, iter_sitemap_urls
+from audiobooker.index import BookIndex, IndexedSource
 
 try:
     from audiobooker.scrappers.youtube import YoutubeChannelSource, YoutubePlaylistSource, TheCybrarian, HorrorBabble

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -2,21 +2,26 @@
 
 Build once, search instantly — no network required after indexing.
 
+Search strategy
+---------------
+Two-phase: SQLite FTS5 pre-filters candidates (token-level, fast), then
+rapidfuzz re-ranks the shortlist with WRatio scoring (typo-tolerant, accurate).
+When FTS returns no hits (e.g. a misspelled query), the search automatically
+falls back to a full rapidfuzz scan so typos never produce zero results.
+
 Usage
 -----
     from audiobooker.index import BookIndex
 
-    # Build (or update) the index from all sources
     idx = BookIndex()
     idx.build()                          # iterate_all() on every source
     idx.build(sources=[Librivox()])      # specific sources only
     idx.update(sources=[Librivox()])     # add new books, skip existing
 
-    # Search offline
     for book in idx.search_by_title("Sherlock Holmes"):
         print(book.title, book.score)
 
-    # Use as a drop-in AudioBookSource in unified search()
+    # Drop-in for unified search()
     from audiobooker import search
     for book in search("Lovecraft", sources=[idx.as_source()]):
         print(book.title)
@@ -31,7 +36,6 @@ CLI
 """
 
 import json
-import os
 import sqlite3
 import time
 from pathlib import Path
@@ -42,23 +46,46 @@ from audiobooker.utils import score_book
 
 _DEFAULT_DB = Path("~/.audiobooker/index.db").expanduser()
 
+# FTS candidate pool — rapidfuzz re-ranks this shortlist.
+# Large enough that the real answer is almost always in it;
+# small enough that re-ranking stays fast even at 18k books.
+_FTS_CANDIDATE_LIMIT = 500
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS books (
-    hash        INTEGER PRIMARY KEY,
-    title       TEXT NOT NULL,
-    description TEXT DEFAULT '',
-    image       TEXT DEFAULT '',
-    language    TEXT DEFAULT '',
-    year        INTEGER DEFAULT 0,
-    runtime     INTEGER DEFAULT 0,
-    source      TEXT DEFAULT '',
-    streams     TEXT DEFAULT '[]',
-    tags        TEXT DEFAULT '[]',
-    authors     TEXT DEFAULT '[]',
-    narrator    TEXT
+    id            INTEGER PRIMARY KEY,
+    hash          INTEGER UNIQUE NOT NULL,
+    title         TEXT NOT NULL,
+    description   TEXT DEFAULT '',
+    image         TEXT DEFAULT '',
+    language      TEXT DEFAULT '',
+    year          INTEGER DEFAULT 0,
+    runtime       INTEGER DEFAULT 0,
+    source        TEXT DEFAULT '',
+    streams       TEXT DEFAULT '[]',
+    tags          TEXT DEFAULT '[]',
+    authors       TEXT DEFAULT '[]',
+    narrator      TEXT,
+    -- Flattened plaintext copies for FTS indexing
+    authors_text  TEXT DEFAULT '',
+    tags_text     TEXT DEFAULT '',
+    narrator_text TEXT DEFAULT ''
 );
+CREATE INDEX IF NOT EXISTS idx_hash     ON books (hash);
 CREATE INDEX IF NOT EXISTS idx_source   ON books (source);
 CREATE INDEX IF NOT EXISTS idx_language ON books (language);
+
+-- FTS5 content table — kept in sync via _fts_insert / _fts_delete helpers.
+-- Columns mirror the four searchable text fields; rowid links to books.id.
+CREATE VIRTUAL TABLE IF NOT EXISTS books_fts USING fts5(
+    title,
+    authors_text,
+    tags_text,
+    narrator_text,
+    content=books,
+    content_rowid=id,
+    tokenize='unicode61 remove_diacritics 1'
+);
 """
 
 
@@ -66,26 +93,45 @@ CREATE INDEX IF NOT EXISTS idx_language ON books (language);
 # Serialisation helpers
 # ---------------------------------------------------------------------------
 
-def _book_to_row(book: AudioBook) -> dict:
-    narrator = None
+def _flatten_authors(book: AudioBook) -> str:
+    return " ".join(
+        f"{a.first_name} {a.last_name}".strip() for a in book.authors
+    )
+
+
+def _flatten_tags(book: AudioBook) -> str:
+    return " ".join(book.tags)
+
+
+def _flatten_narrator(book: AudioBook) -> str:
     if book.narrator:
-        narrator = json.dumps({"first_name": book.narrator.first_name,
-                               "last_name": book.narrator.last_name})
+        return f"{book.narrator.first_name} {book.narrator.last_name}".strip()
+    return ""
+
+
+def _book_to_row(book: AudioBook) -> dict:
+    narrator_json = None
+    if book.narrator:
+        narrator_json = json.dumps({"first_name": book.narrator.first_name,
+                                    "last_name":  book.narrator.last_name})
     return {
-        "hash":        hash(book),
-        "title":       book.title,
-        "description": book.description,
-        "image":       book.image,
-        "language":    book.language,
-        "year":        book.year,
-        "runtime":     book.runtime,
-        "source":      book.source,
-        "streams":     json.dumps(book.streams),
-        "tags":        json.dumps(book.tags),
-        "authors":     json.dumps([{"first_name": a.first_name,
-                                    "last_name": a.last_name}
-                                   for a in book.authors]),
-        "narrator":    narrator,
+        "hash":          hash(book),
+        "title":         book.title,
+        "description":   book.description,
+        "image":         book.image,
+        "language":      book.language,
+        "year":          book.year,
+        "runtime":       book.runtime,
+        "source":        book.source,
+        "streams":       json.dumps(book.streams),
+        "tags":          json.dumps(book.tags),
+        "authors":       json.dumps([{"first_name": a.first_name,
+                                      "last_name":  a.last_name}
+                                     for a in book.authors]),
+        "narrator":      narrator_json,
+        "authors_text":  _flatten_authors(book),
+        "tags_text":     _flatten_tags(book),
+        "narrator_text": _flatten_narrator(book),
     }
 
 
@@ -107,6 +153,26 @@ def _row_to_book(row: sqlite3.Row) -> AudioBook:
         authors=authors,
         narrator=narrator,
     )
+
+
+# ---------------------------------------------------------------------------
+# FTS query builder
+# ---------------------------------------------------------------------------
+
+def _fts_query(query: str, field: Optional[str] = None) -> str:
+    """Build an FTS5 MATCH expression from a free-text query.
+
+    Each word becomes a prefix term so "love" matches "Lovecraft".
+    Multi-word queries use OR so partial matches still surface results.
+    """
+    tokens = [w.strip('"\'.,:;!?') for w in query.split() if w.strip('"\'.,:;!?')]
+    if not tokens:
+        return '""'
+    # Prefix-match each token; quote to handle special chars
+    terms = " OR ".join(f'"{t}"*' for t in tokens)
+    if field:
+        return f"{field}:({terms})"
+    return terms
 
 
 # ---------------------------------------------------------------------------
@@ -136,30 +202,26 @@ class BookIndex:
     # ------------------------------------------------------------------
 
     def build(self, sources=None, progress: bool = True) -> int:
-        """Clear all records for the given sources and repopulate.
+        """Clear records for the given sources and repopulate from scratch.
 
-        Parameters
-        ----------
-        sources:
-            List of instantiated ``AudioBookSource`` objects.
-            Defaults to all web sources (YouTube excluded — those change too
-            fast to be worth indexing).
-        progress:
-            Print a one-line progress indicator per source.
+        Rebuilds the FTS index after each source completes.
 
-        Returns
-        -------
-        int
-            Total number of books inserted.
+        Returns the total number of books inserted.
         """
         if sources is None:
             sources = _default_sources()
         total = 0
         for source in sources:
             name = source.__class__.__name__
-            # Remove existing records for this source so a full rebuild is clean
-            self._con.execute("DELETE FROM books WHERE source = ?", (name,))
+            # Delete existing books for this source and their FTS entries
+            ids = [r[0] for r in self._con.execute(
+                "SELECT id FROM books WHERE source = ?", (name,)
+            ).fetchall()]
+            if ids:
+                self._fts_delete_ids(ids)
+                self._con.execute("DELETE FROM books WHERE source = ?", (name,))
             self._con.commit()
+
             count = 0
             t0 = time.monotonic()
             for book in source.iterate_all():
@@ -168,6 +230,8 @@ class BookIndex:
                 if progress and count % 50 == 0:
                     print(f"  {name}: {count} books…", end="\r", flush=True)
             self._con.commit()
+            # Rebuild FTS for this source's rows
+            self._fts_rebuild()
             elapsed = time.monotonic() - t0
             if progress:
                 print(f"  {name}: {count} books indexed in {elapsed:.1f}s")
@@ -179,10 +243,7 @@ class BookIndex:
 
         Uses ``AudioBook.__hash__`` (title + authors) as the uniqueness key.
 
-        Returns
-        -------
-        int
-            Number of new books inserted.
+        Returns the number of new books inserted.
         """
         if sources is None:
             sources = _default_sources()
@@ -191,37 +252,119 @@ class BookIndex:
             name = source.__class__.__name__
             count = 0
             t0 = time.monotonic()
+            new_ids = []
             for book in source.iterate_all():
-                h = hash(book)
-                exists = self._con.execute(
-                    "SELECT 1 FROM books WHERE hash = ?", (h,)
-                ).fetchone()
-                if not exists:
-                    self._upsert(book)
+                row_id = self._upsert_if_new(book)
+                if row_id is not None:
+                    new_ids.append(row_id)
                     count += 1
-            self._con.commit()
+            if new_ids:
+                self._con.commit()
+                self._fts_insert_ids(new_ids)
             elapsed = time.monotonic() - t0
             if progress:
                 print(f"  {name}: {count} new books in {elapsed:.1f}s")
             total += count
         return total
 
+    # ------------------------------------------------------------------
+    # Low-level write helpers
+    # ------------------------------------------------------------------
+
     def _upsert(self, book: AudioBook):
         row = _book_to_row(book)
         self._con.execute("""
             INSERT OR REPLACE INTO books
               (hash, title, description, image, language, year, runtime,
-               source, streams, tags, authors, narrator)
+               source, streams, tags, authors, narrator,
+               authors_text, tags_text, narrator_text)
             VALUES
               (:hash, :title, :description, :image, :language, :year, :runtime,
-               :source, :streams, :tags, :authors, :narrator)
+               :source, :streams, :tags, :authors, :narrator,
+               :authors_text, :tags_text, :narrator_text)
         """, row)
+
+    def _upsert_if_new(self, book: AudioBook) -> Optional[int]:
+        """Insert book if not already present. Returns new rowid or None."""
+        h = hash(book)
+        existing = self._con.execute(
+            "SELECT id FROM books WHERE hash = ?", (h,)
+        ).fetchone()
+        if existing:
+            return None
+        row = _book_to_row(book)
+        cur = self._con.execute("""
+            INSERT INTO books
+              (hash, title, description, image, language, year, runtime,
+               source, streams, tags, authors, narrator,
+               authors_text, tags_text, narrator_text)
+            VALUES
+              (:hash, :title, :description, :image, :language, :year, :runtime,
+               :source, :streams, :tags, :authors, :narrator,
+               :authors_text, :tags_text, :narrator_text)
+        """, row)
+        return cur.lastrowid
+
+    # ------------------------------------------------------------------
+    # FTS maintenance
+    # ------------------------------------------------------------------
+
+    def _fts_rebuild(self):
+        """Rebuild the entire FTS index from the books table."""
+        self._con.execute("INSERT INTO books_fts(books_fts) VALUES('rebuild')")
+        self._con.commit()
+
+    def _fts_insert_ids(self, ids: List[int]):
+        """Insert specific book rows into FTS by their rowid."""
+        for row_id in ids:
+            self._con.execute("""
+                INSERT INTO books_fts(rowid, title, authors_text, tags_text, narrator_text)
+                SELECT id, title, authors_text, tags_text, narrator_text
+                FROM books WHERE id = ?
+            """, (row_id,))
+        self._con.commit()
+
+    def _fts_delete_ids(self, ids: List[int]):
+        """Remove specific rows from FTS before deleting from main table."""
+        for row_id in ids:
+            self._con.execute("""
+                INSERT INTO books_fts(books_fts, rowid, title, authors_text, tags_text, narrator_text)
+                SELECT 'delete', id, title, authors_text, tags_text, narrator_text
+                FROM books WHERE id = ?
+            """, (row_id,))
+        self._con.commit()
 
     # ------------------------------------------------------------------
     # Querying
     # ------------------------------------------------------------------
 
-    def _all_books(self, source: Optional[str] = None,
+    def _fts_search(self, query: str, field: Optional[str] = None,
+                    source: Optional[str] = None,
+                    language: Optional[str] = None) -> List[AudioBook]:
+        """FTS5 pre-filter returning up to _FTS_CANDIDATE_LIMIT candidates."""
+        fts_q = _fts_query(query, field)
+        filters, params = ["books_fts MATCH ?"], [fts_q]
+        if source:
+            filters.append("b.source = ?")
+            params.append(source)
+        if language:
+            filters.append("b.language = ?")
+            params.append(language)
+        where = " AND ".join(filters)
+        params.append(_FTS_CANDIDATE_LIMIT)
+        try:
+            rows = self._con.execute(f"""
+                SELECT b.* FROM books b
+                JOIN books_fts ON books_fts.rowid = b.id
+                WHERE {where}
+                ORDER BY rank
+                LIMIT ?
+            """, params).fetchall()
+            return [_row_to_book(r) for r in rows]
+        except sqlite3.OperationalError:
+            return []
+
+    def _full_scan(self, source: Optional[str] = None,
                    language: Optional[str] = None) -> List[AudioBook]:
         clauses, params = [], []
         if source:
@@ -231,81 +374,89 @@ class BookIndex:
             clauses.append("language = ?")
             params.append(language)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
-        rows = self._con.execute(f"SELECT * FROM books {where}", params).fetchall()
+        rows = self._con.execute(
+            f"SELECT * FROM books {where}", params
+        ).fetchall()
         return [_row_to_book(r) for r in rows]
 
-    def search_by_title(self, query: str, max_results: int = 10,
-                        min_score: float = 0.45,
-                        source: Optional[str] = None,
-                        language: Optional[str] = None) -> List[AudioBook]:
+    def _rank(self, query: str, books: List[AudioBook], method: str,
+              min_score: float, max_results: int) -> List[AudioBook]:
         results = []
-        for book in self._all_books(source, language):
-            book.score = score_book(query, book, "search_by_title")
+        for book in books:
+            book.score = score_book(query, book, method)
             if book.score >= min_score:
                 results.append(book)
         results.sort(key=lambda b: b.score, reverse=True)
         return results[:max_results] if max_results else results
 
-    def search_by_author(self, query: str, max_results: int = 10,
-                         min_score: float = 0.45,
-                         source: Optional[str] = None,
-                         language: Optional[str] = None) -> List[AudioBook]:
-        results = []
-        for book in self._all_books(source, language):
-            book.score = score_book(query, book, "search_by_author")
-            if book.score >= min_score:
-                results.append(book)
-        results.sort(key=lambda b: b.score, reverse=True)
-        return results[:max_results] if max_results else results
+    def _search(self, query: str, method: str,
+                fts_field: Optional[str],
+                max_results: int, min_score: float,
+                source: Optional[str], language: Optional[str],
+                fts_fallback_threshold: int = 5) -> List[AudioBook]:
+        """Two-phase search: FTS pre-filter → rapidfuzz re-rank.
 
-    def search_by_tag(self, query: str, max_results: int = 10,
-                      min_score: float = 0.45,
-                      source: Optional[str] = None,
-                      language: Optional[str] = None) -> List[AudioBook]:
-        results = []
-        for book in self._all_books(source, language):
-            book.score = score_book(query, book, "search_by_tag")
-            if book.score >= min_score:
-                results.append(book)
-        results.sort(key=lambda b: b.score, reverse=True)
-        return results[:max_results] if max_results else results
-
-    def search_by_narrator(self, query: str, max_results: int = 10,
-                           min_score: float = 0.45,
-                           source: Optional[str] = None,
-                           language: Optional[str] = None) -> List[AudioBook]:
-        results = []
-        for book in self._all_books(source, language):
-            if not book.narrator:
-                continue
-            book.score = score_book(query, book, "search_by_narrator")
-            if book.score >= min_score:
-                results.append(book)
-        results.sort(key=lambda b: b.score, reverse=True)
-        return results[:max_results] if max_results else results
+        Falls back to a full table scan when FTS returns fewer than
+        ``fts_fallback_threshold`` hits (handles typos and rare terms).
+        """
+        candidates = self._fts_search(query, fts_field, source, language)
+        if len(candidates) < fts_fallback_threshold:
+            # Broaden: try without field restriction
+            if fts_field:
+                candidates = self._fts_search(query, None, source, language)
+            # Still too few — full rapidfuzz scan (typo tolerance)
+            if len(candidates) < fts_fallback_threshold:
+                candidates = self._full_scan(source, language)
+        return self._rank(query, candidates, method, min_score, max_results)
 
     def search(self, query: str, max_results: int = 10,
                min_score: float = 0.45,
                source: Optional[str] = None,
                language: Optional[str] = None) -> List[AudioBook]:
-        results = []
-        for book in self._all_books(source, language):
-            book.score = score_book(query, book, "search")
-            if book.score >= min_score:
-                results.append(book)
-        results.sort(key=lambda b: b.score, reverse=True)
-        return results[:max_results] if max_results else results
+        return self._search(query, "search", None,
+                            max_results, min_score, source, language)
+
+    def search_by_title(self, query: str, max_results: int = 10,
+                        min_score: float = 0.45,
+                        source: Optional[str] = None,
+                        language: Optional[str] = None) -> List[AudioBook]:
+        return self._search(query, "search_by_title", "title",
+                            max_results, min_score, source, language)
+
+    def search_by_author(self, query: str, max_results: int = 10,
+                         min_score: float = 0.45,
+                         source: Optional[str] = None,
+                         language: Optional[str] = None) -> List[AudioBook]:
+        return self._search(query, "search_by_author", "authors_text",
+                            max_results, min_score, source, language)
+
+    def search_by_tag(self, query: str, max_results: int = 10,
+                      min_score: float = 0.45,
+                      source: Optional[str] = None,
+                      language: Optional[str] = None) -> List[AudioBook]:
+        return self._search(query, "search_by_tag", "tags_text",
+                            max_results, min_score, source, language)
+
+    def search_by_narrator(self, query: str, max_results: int = 10,
+                           min_score: float = 0.45,
+                           source: Optional[str] = None,
+                           language: Optional[str] = None) -> List[AudioBook]:
+        return self._search(query, "search_by_narrator", "narrator_text",
+                            max_results, min_score, source, language)
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
 
     def iterate_all(self, source: Optional[str] = None,
                     language: Optional[str] = None) -> Iterable[AudioBook]:
-        yield from self._all_books(source, language)
+        yield from self._full_scan(source, language)
 
     # ------------------------------------------------------------------
-    # Stats
+    # Stats / meta
     # ------------------------------------------------------------------
 
     def stats(self) -> dict:
-        """Return a summary dict: total books, per-source counts, languages."""
         total = self._con.execute("SELECT COUNT(*) FROM books").fetchone()[0]
         by_source = dict(self._con.execute(
             "SELECT source, COUNT(*) FROM books GROUP BY source ORDER BY COUNT(*) DESC"
@@ -315,12 +466,7 @@ class BookIndex:
         ).fetchall())
         return {"total": total, "by_source": by_source, "by_language": by_language}
 
-    # ------------------------------------------------------------------
-    # AudioBookSource adapter
-    # ------------------------------------------------------------------
-
     def as_source(self) -> "IndexedSource":
-        """Return an AudioBookSource backed by this index."""
         return IndexedSource(self)
 
     def __len__(self) -> int:
@@ -346,9 +492,8 @@ class BookIndex:
 class IndexedSource:
     """AudioBookSource interface backed by a BookIndex.
 
-    Supports the full search API and can be used anywhere an
-    ``AudioBookSource`` is accepted, including ``sources=`` in
-    ``audiobooker.search()``.
+    Can be used anywhere an ``AudioBookSource`` is accepted, including
+    ``sources=`` in ``audiobooker.search()``.
 
     Parameters
     ----------
@@ -376,12 +521,14 @@ class IndexedSource:
         return self.iterate_all()
 
     def iterate_by_author(self, author: str) -> Iterable[AudioBook]:
-        for book in self._index.search_by_author(author, max_results=0):
-            yield book
+        yield from self._index.search_by_author(author, max_results=0,
+                                                source=self._source,
+                                                language=self._language)
 
     def iterate_by_tag(self, tag: str) -> Iterable[AudioBook]:
-        for book in self._index.search_by_tag(tag, max_results=0):
-            yield book
+        yield from self._index.search_by_tag(tag, max_results=0,
+                                             source=self._source,
+                                             language=self._language)
 
     def search(self, query: str) -> Iterable[AudioBook]:
         yield from self._index.search(query, max_results=0,
@@ -413,7 +560,7 @@ class IndexedSource:
 
 
 # ---------------------------------------------------------------------------
-# Default sources for build/update (web only, no YouTube)
+# Default sources (web only — no YouTube)
 # ---------------------------------------------------------------------------
 
 def _default_sources():
@@ -425,13 +572,8 @@ def _default_sources():
     from audiobooker.scrappers.hpaudiotales import HPTalesAudioBooks
     from audiobooker.scrappers.stephenkingaudiobooks import StephenKingAudioBooks
     return [
-        Librivox(),
-        LoyalBooks(),
-        StephenKingAudioBooks(),
-        GoldenAudioBooks(),
-        AudioAnarchy(),
-        DarkerProjects(),
-        HPTalesAudioBooks(),
+        Librivox(), LoyalBooks(), StephenKingAudioBooks(),
+        GoldenAudioBooks(), AudioAnarchy(), DarkerProjects(), HPTalesAudioBooks(),
     ]
 
 
@@ -476,23 +618,23 @@ def main():
     sub = parser.add_subparsers(dest="cmd")
 
     p_build = sub.add_parser("build", help="(Re)build index for all or selected sources")
-    p_build.add_argument("--sources", nargs="*", help="Sources to index (default: all)")
+    p_build.add_argument("--sources", nargs="*")
 
-    p_update = sub.add_parser("update", help="Add new books without clearing existing records")
-    p_update.add_argument("--sources", nargs="*", help="Sources to update (default: all)")
+    p_update = sub.add_parser("update", help="Add new books without clearing existing")
+    p_update.add_argument("--sources", nargs="*")
 
-    p_stats = sub.add_parser("stats", help="Show index statistics")
+    sub.add_parser("stats", help="Show index statistics")
 
     p_search = sub.add_parser("search", help="Search the index")
     p_search.add_argument("query")
     p_search.add_argument("--method", default="search",
                           choices=["search", "search_by_title", "search_by_author",
                                    "search_by_tag", "search_by_narrator"])
-    p_search.add_argument("--n", type=int, default=10, help="Max results")
-    p_search.add_argument("--source", default=None, help="Filter by source name")
+    p_search.add_argument("--n", type=int, default=10)
+    p_search.add_argument("--source", default=None)
+    p_search.add_argument("--language", default=None)
 
     args = parser.parse_args()
-
     idx = BookIndex(args.db)
 
     if args.cmd == "build":
@@ -519,8 +661,12 @@ def main():
 
     elif args.cmd == "search":
         fn = getattr(idx, args.method)
-        results = fn(args.query, max_results=args.n,
-                     **({'source': args.source} if args.source else {}))
+        kw = {}
+        if args.source:
+            kw["source"] = args.source
+        if args.language:
+            kw["language"] = args.language
+        results = fn(args.query, max_results=args.n, **kw)
         print(f"{len(results)} result(s) for {args.query!r}:\n")
         for book in results:
             authors = ", ".join(

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -52,6 +52,19 @@ _DEFAULT_DB = Path("~/.audiobooker/index.db").expanduser()
 _FTS_CANDIDATE_LIMIT = 500
 
 _SCHEMA = """
+CREATE TABLE IF NOT EXISTS followed_sources (
+    id              INTEGER PRIMARY KEY,
+    kind            TEXT NOT NULL,   -- 'channel' or 'playlist'
+    url             TEXT NOT NULL UNIQUE,
+    name            TEXT DEFAULT '',
+    tags            TEXT DEFAULT '[]',
+    authors         TEXT DEFAULT '[]',
+    narrator        TEXT,
+    language        TEXT DEFAULT 'en',
+    min_runtime     INTEGER DEFAULT 300,
+    title_blacklist TEXT DEFAULT '[]'
+);
+
 CREATE TABLE IF NOT EXISTS books (
     id            INTEGER PRIMARY KEY,
     hash          INTEGER UNIQUE NOT NULL,
@@ -199,16 +212,26 @@ class BookIndex:
         self._con.commit()
 
     def _migrate(self):
-        """Drop and recreate tables if the schema is outdated (missing id column)."""
+        """Evolve schema to current version without destroying data."""
+        # v1→v2: books table got an auto-increment id column
         cols = {r[1] for r in self._con.execute(
             "PRAGMA table_info(books)"
         ).fetchall()}
         if cols and "id" not in cols:
-            # Old schema — drop everything and let _SCHEMA recreate cleanly
             self._con.executescript("""
                 DROP TABLE IF EXISTS books_fts;
                 DROP TABLE IF EXISTS books;
             """)
+            self._con.commit()
+
+        # v2→v3: followed_sources got title_blacklist column
+        fs_cols = {r[1] for r in self._con.execute(
+            "PRAGMA table_info(followed_sources)"
+        ).fetchall()}
+        if fs_cols and "title_blacklist" not in fs_cols:
+            self._con.execute(
+                "ALTER TABLE followed_sources ADD COLUMN title_blacklist TEXT DEFAULT '[]'"
+            )
             self._con.commit()
 
     # ------------------------------------------------------------------
@@ -256,11 +279,13 @@ class BookIndex:
         """Add books not yet in the index; skip existing records.
 
         Uses ``AudioBook.__hash__`` (title + authors) as the uniqueness key.
+        When ``sources`` is ``None``, also includes any channels/playlists
+        registered via ``follow()``.
 
         Returns the number of new books inserted.
         """
         if sources is None:
-            sources = _default_sources()
+            sources = _default_sources() + self._followed_as_sources()
         total = 0
         for source in sources:
             name = source.__class__.__name__
@@ -470,6 +495,118 @@ class BookIndex:
         yield from self._full_scan(source, language)
 
     # ------------------------------------------------------------------
+    # Followed YouTube sources
+    # ------------------------------------------------------------------
+
+    def follow(self, url: str, kind: str = "channel", *,
+               name: str = "",
+               tags: Optional[List[str]] = None,
+               authors: Optional[List[BookAuthor]] = None,
+               narrator=None,
+               language: str = "en",
+               min_runtime: int = 300,
+               title_blacklist: Optional[List[str]] = None) -> None:
+        """Register a YouTube channel or playlist to be included in update().
+
+        Parameters
+        ----------
+        url:
+            Full YouTube channel URL (``https://www.youtube.com/@Name/videos``)
+            or playlist URL (``https://www.youtube.com/playlist?list=PLxxx``).
+        kind:
+            ``"channel"`` or ``"playlist"``.
+        name:
+            Human-readable label (displayed in ``list_followed()``).
+        tags:
+            Tags stamped on every book from this source.
+        authors:
+            Default author list (extraction can override per-video).
+        narrator:
+            Default narrator stamped on every book.
+        language:
+            ISO 639-1 code, default ``"en"``.
+        min_runtime:
+            Skip videos shorter than this many seconds.
+        """
+        narrator_json = None
+        if narrator is not None:
+            narrator_json = json.dumps({"first_name": narrator.first_name,
+                                        "last_name":  narrator.last_name})
+        authors_json = json.dumps([{"first_name": a.first_name,
+                                    "last_name":  a.last_name}
+                                   for a in (authors or [])])
+        self._con.execute("""
+            INSERT OR REPLACE INTO followed_sources
+              (kind, url, name, tags, authors, narrator, language, min_runtime, title_blacklist)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (kind, url, name, json.dumps(tags or []),
+              authors_json, narrator_json, language, min_runtime,
+              json.dumps(title_blacklist or [])))
+        self._con.commit()
+
+    def unfollow(self, url: str) -> bool:
+        """Remove a followed source by URL. Returns True if it existed."""
+        cur = self._con.execute(
+            "DELETE FROM followed_sources WHERE url = ?", (url,)
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_followed(self) -> List[dict]:
+        """Return all followed sources as a list of dicts."""
+        rows = self._con.execute(
+            "SELECT * FROM followed_sources ORDER BY kind, name, url"
+        ).fetchall()
+        result = []
+        for r in rows:
+            result.append({
+                "kind":            r["kind"],
+                "url":             r["url"],
+                "name":            r["name"],
+                "tags":            json.loads(r["tags"]),
+                "authors":         json.loads(r["authors"]),
+                "narrator":        json.loads(r["narrator"]) if r["narrator"] else None,
+                "language":        r["language"],
+                "min_runtime":     r["min_runtime"],
+                "title_blacklist": json.loads(r["title_blacklist"]) if r["title_blacklist"] else [],
+            })
+        return result
+
+    def _followed_as_sources(self):
+        """Instantiate all followed YouTube sources."""
+        try:
+            from audiobooker.scrappers.youtube import (
+                YoutubeChannelSource, YoutubePlaylistSource
+            )
+        except ImportError:
+            return []
+
+        sources = []
+        for f in self.list_followed():
+            authors = [BookAuthor(**a) for a in f["authors"]]
+            narrator = None
+            if f["narrator"]:
+                from audiobooker.base import AudiobookNarrator
+                narrator = AudiobookNarrator(**f["narrator"])
+            kwargs = dict(
+                authors=authors,
+                narrator=narrator,
+                tags=f["tags"],
+                language=f["language"],
+                min_runtime=f["min_runtime"],
+                title_blacklist=f["title_blacklist"],
+            )
+            if f["kind"] == "playlist":
+                sources.append(YoutubePlaylistSource(
+                    playlist_url=f["url"], **kwargs
+                ))
+            else:
+                sources.append(YoutubeChannelSource(
+                    channel_url=f["url"], **kwargs
+                ))
+        return sources
+
+    # ------------------------------------------------------------------
     # Stats / meta
     # ------------------------------------------------------------------
 
@@ -651,6 +788,22 @@ def main():
     p_search.add_argument("--source", default=None)
     p_search.add_argument("--language", default=None)
 
+    p_follow = sub.add_parser("follow", help="Follow a YouTube channel or playlist")
+    p_follow.add_argument("url", help="Channel or playlist URL")
+    p_follow.add_argument("--kind", default="channel", choices=["channel", "playlist"])
+    p_follow.add_argument("--name", default="", help="Human-readable label")
+    p_follow.add_argument("--tags", nargs="*", default=[], metavar="TAG")
+    p_follow.add_argument("--language", default="en")
+    p_follow.add_argument("--min-runtime", type=int, default=300,
+                          help="Skip videos shorter than N seconds (default 300)")
+    p_follow.add_argument("--blacklist", nargs="*", default=[], metavar="PHRASE",
+                          help="Skip books whose title contains any of these strings")
+
+    p_unfollow = sub.add_parser("unfollow", help="Stop following a channel or playlist")
+    p_unfollow.add_argument("url", help="Channel or playlist URL to remove")
+
+    sub.add_parser("list", help="List followed YouTube sources")
+
     args = parser.parse_args()
     idx = BookIndex(args.db)
 
@@ -665,6 +818,33 @@ def main():
         print("Updating index…")
         total = idx.update(sources=sources)
         print(f"Done. {total} new books added.")
+
+    elif args.cmd == "follow":
+        idx.follow(args.url, kind=args.kind, name=args.name,
+                   tags=args.tags, language=args.language,
+                   min_runtime=args.min_runtime,
+                   title_blacklist=args.blacklist)
+        label = args.name or args.url
+        print(f"Following {args.kind}: {label}")
+
+    elif args.cmd == "unfollow":
+        removed = idx.unfollow(args.url)
+        if removed:
+            print(f"Unfollowed: {args.url}")
+        else:
+            print(f"Not found: {args.url}")
+
+    elif args.cmd == "list":
+        followed = idx.list_followed()
+        if not followed:
+            print("No followed sources.")
+        else:
+            print(f"{'Kind':<10} {'Name/URL':<50} {'Language':<8} {'Tags'}")
+            print("-" * 80)
+            for f in followed:
+                label = f["name"] or f["url"]
+                tags = ", ".join(f["tags"]) if f["tags"] else ""
+                print(f"  {f['kind']:<8} {label:<50} {f['language']:<8} {tags}")
 
     elif args.cmd == "stats":
         s = idx.stats()

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -194,8 +194,22 @@ class BookIndex:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._con = sqlite3.connect(str(self.db_path))
         self._con.row_factory = sqlite3.Row
+        self._migrate()
         self._con.executescript(_SCHEMA)
         self._con.commit()
+
+    def _migrate(self):
+        """Drop and recreate tables if the schema is outdated (missing id column)."""
+        cols = {r[1] for r in self._con.execute(
+            "PRAGMA table_info(books)"
+        ).fetchall()}
+        if cols and "id" not in cols:
+            # Old schema — drop everything and let _SCHEMA recreate cleanly
+            self._con.executescript("""
+                DROP TABLE IF EXISTS books_fts;
+                DROP TABLE IF EXISTS books;
+            """)
+            self._con.commit()
 
     # ------------------------------------------------------------------
     # Building
@@ -383,6 +397,9 @@ class BookIndex:
               min_score: float, max_results: int) -> List[AudioBook]:
         results = []
         for book in books:
+            # narrator search: skip books that have no narrator at all
+            if method == "search_by_narrator" and not book.narrator:
+                continue
             book.score = score_book(query, book, method)
             if book.score >= min_score:
                 results.append(book)

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -1,0 +1,539 @@
+"""Persistent SQLite index for AudioBook catalogues.
+
+Build once, search instantly — no network required after indexing.
+
+Usage
+-----
+    from audiobooker.index import BookIndex
+
+    # Build (or update) the index from all sources
+    idx = BookIndex()
+    idx.build()                          # iterate_all() on every source
+    idx.build(sources=[Librivox()])      # specific sources only
+    idx.update(sources=[Librivox()])     # add new books, skip existing
+
+    # Search offline
+    for book in idx.search_by_title("Sherlock Holmes"):
+        print(book.title, book.score)
+
+    # Use as a drop-in AudioBookSource in unified search()
+    from audiobooker import search
+    for book in search("Lovecraft", sources=[idx.as_source()]):
+        print(book.title)
+
+CLI
+---
+    python -m audiobooker.index build
+    python -m audiobooker.index build --sources librivox loyalbooks
+    python -m audiobooker.index update
+    python -m audiobooker.index stats
+    python -m audiobooker.index search "Lovecraft"
+"""
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from audiobooker.base import AudioBook, BookAuthor, AudiobookNarrator
+from audiobooker.utils import score_book
+
+_DEFAULT_DB = Path("~/.audiobooker/index.db").expanduser()
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS books (
+    hash        INTEGER PRIMARY KEY,
+    title       TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    image       TEXT DEFAULT '',
+    language    TEXT DEFAULT '',
+    year        INTEGER DEFAULT 0,
+    runtime     INTEGER DEFAULT 0,
+    source      TEXT DEFAULT '',
+    streams     TEXT DEFAULT '[]',
+    tags        TEXT DEFAULT '[]',
+    authors     TEXT DEFAULT '[]',
+    narrator    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_source   ON books (source);
+CREATE INDEX IF NOT EXISTS idx_language ON books (language);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+def _book_to_row(book: AudioBook) -> dict:
+    narrator = None
+    if book.narrator:
+        narrator = json.dumps({"first_name": book.narrator.first_name,
+                               "last_name": book.narrator.last_name})
+    return {
+        "hash":        hash(book),
+        "title":       book.title,
+        "description": book.description,
+        "image":       book.image,
+        "language":    book.language,
+        "year":        book.year,
+        "runtime":     book.runtime,
+        "source":      book.source,
+        "streams":     json.dumps(book.streams),
+        "tags":        json.dumps(book.tags),
+        "authors":     json.dumps([{"first_name": a.first_name,
+                                    "last_name": a.last_name}
+                                   for a in book.authors]),
+        "narrator":    narrator,
+    }
+
+
+def _row_to_book(row: sqlite3.Row) -> AudioBook:
+    authors = [BookAuthor(**a) for a in json.loads(row["authors"])]
+    narrator = None
+    if row["narrator"]:
+        narrator = AudiobookNarrator(**json.loads(row["narrator"]))
+    return AudioBook(
+        title=row["title"],
+        description=row["description"],
+        image=row["image"],
+        language=row["language"],
+        year=row["year"],
+        runtime=row["runtime"],
+        source=row["source"],
+        streams=json.loads(row["streams"]),
+        tags=json.loads(row["tags"]),
+        authors=authors,
+        narrator=narrator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BookIndex
+# ---------------------------------------------------------------------------
+
+class BookIndex:
+    """SQLite-backed persistent index of AudioBook records.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.
+        Defaults to ``~/.audiobooker/index.db``.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = Path(db_path) if db_path else _DEFAULT_DB
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(str(self.db_path))
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript(_SCHEMA)
+        self._con.commit()
+
+    # ------------------------------------------------------------------
+    # Building
+    # ------------------------------------------------------------------
+
+    def build(self, sources=None, progress: bool = True) -> int:
+        """Clear all records for the given sources and repopulate.
+
+        Parameters
+        ----------
+        sources:
+            List of instantiated ``AudioBookSource`` objects.
+            Defaults to all web sources (YouTube excluded — those change too
+            fast to be worth indexing).
+        progress:
+            Print a one-line progress indicator per source.
+
+        Returns
+        -------
+        int
+            Total number of books inserted.
+        """
+        if sources is None:
+            sources = _default_sources()
+        total = 0
+        for source in sources:
+            name = source.__class__.__name__
+            # Remove existing records for this source so a full rebuild is clean
+            self._con.execute("DELETE FROM books WHERE source = ?", (name,))
+            self._con.commit()
+            count = 0
+            t0 = time.monotonic()
+            for book in source.iterate_all():
+                self._upsert(book)
+                count += 1
+                if progress and count % 50 == 0:
+                    print(f"  {name}: {count} books…", end="\r", flush=True)
+            self._con.commit()
+            elapsed = time.monotonic() - t0
+            if progress:
+                print(f"  {name}: {count} books indexed in {elapsed:.1f}s")
+            total += count
+        return total
+
+    def update(self, sources=None, progress: bool = True) -> int:
+        """Add books not yet in the index; skip existing records.
+
+        Uses ``AudioBook.__hash__`` (title + authors) as the uniqueness key.
+
+        Returns
+        -------
+        int
+            Number of new books inserted.
+        """
+        if sources is None:
+            sources = _default_sources()
+        total = 0
+        for source in sources:
+            name = source.__class__.__name__
+            count = 0
+            t0 = time.monotonic()
+            for book in source.iterate_all():
+                h = hash(book)
+                exists = self._con.execute(
+                    "SELECT 1 FROM books WHERE hash = ?", (h,)
+                ).fetchone()
+                if not exists:
+                    self._upsert(book)
+                    count += 1
+            self._con.commit()
+            elapsed = time.monotonic() - t0
+            if progress:
+                print(f"  {name}: {count} new books in {elapsed:.1f}s")
+            total += count
+        return total
+
+    def _upsert(self, book: AudioBook):
+        row = _book_to_row(book)
+        self._con.execute("""
+            INSERT OR REPLACE INTO books
+              (hash, title, description, image, language, year, runtime,
+               source, streams, tags, authors, narrator)
+            VALUES
+              (:hash, :title, :description, :image, :language, :year, :runtime,
+               :source, :streams, :tags, :authors, :narrator)
+        """, row)
+
+    # ------------------------------------------------------------------
+    # Querying
+    # ------------------------------------------------------------------
+
+    def _all_books(self, source: Optional[str] = None,
+                   language: Optional[str] = None) -> List[AudioBook]:
+        clauses, params = [], []
+        if source:
+            clauses.append("source = ?")
+            params.append(source)
+        if language:
+            clauses.append("language = ?")
+            params.append(language)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self._con.execute(f"SELECT * FROM books {where}", params).fetchall()
+        return [_row_to_book(r) for r in rows]
+
+    def search_by_title(self, query: str, max_results: int = 10,
+                        min_score: float = 0.45,
+                        source: Optional[str] = None,
+                        language: Optional[str] = None) -> List[AudioBook]:
+        results = []
+        for book in self._all_books(source, language):
+            book.score = score_book(query, book, "search_by_title")
+            if book.score >= min_score:
+                results.append(book)
+        results.sort(key=lambda b: b.score, reverse=True)
+        return results[:max_results] if max_results else results
+
+    def search_by_author(self, query: str, max_results: int = 10,
+                         min_score: float = 0.45,
+                         source: Optional[str] = None,
+                         language: Optional[str] = None) -> List[AudioBook]:
+        results = []
+        for book in self._all_books(source, language):
+            book.score = score_book(query, book, "search_by_author")
+            if book.score >= min_score:
+                results.append(book)
+        results.sort(key=lambda b: b.score, reverse=True)
+        return results[:max_results] if max_results else results
+
+    def search_by_tag(self, query: str, max_results: int = 10,
+                      min_score: float = 0.45,
+                      source: Optional[str] = None,
+                      language: Optional[str] = None) -> List[AudioBook]:
+        results = []
+        for book in self._all_books(source, language):
+            book.score = score_book(query, book, "search_by_tag")
+            if book.score >= min_score:
+                results.append(book)
+        results.sort(key=lambda b: b.score, reverse=True)
+        return results[:max_results] if max_results else results
+
+    def search_by_narrator(self, query: str, max_results: int = 10,
+                           min_score: float = 0.45,
+                           source: Optional[str] = None,
+                           language: Optional[str] = None) -> List[AudioBook]:
+        results = []
+        for book in self._all_books(source, language):
+            if not book.narrator:
+                continue
+            book.score = score_book(query, book, "search_by_narrator")
+            if book.score >= min_score:
+                results.append(book)
+        results.sort(key=lambda b: b.score, reverse=True)
+        return results[:max_results] if max_results else results
+
+    def search(self, query: str, max_results: int = 10,
+               min_score: float = 0.45,
+               source: Optional[str] = None,
+               language: Optional[str] = None) -> List[AudioBook]:
+        results = []
+        for book in self._all_books(source, language):
+            book.score = score_book(query, book, "search")
+            if book.score >= min_score:
+                results.append(book)
+        results.sort(key=lambda b: b.score, reverse=True)
+        return results[:max_results] if max_results else results
+
+    def iterate_all(self, source: Optional[str] = None,
+                    language: Optional[str] = None) -> Iterable[AudioBook]:
+        yield from self._all_books(source, language)
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict:
+        """Return a summary dict: total books, per-source counts, languages."""
+        total = self._con.execute("SELECT COUNT(*) FROM books").fetchone()[0]
+        by_source = dict(self._con.execute(
+            "SELECT source, COUNT(*) FROM books GROUP BY source ORDER BY COUNT(*) DESC"
+        ).fetchall())
+        by_language = dict(self._con.execute(
+            "SELECT language, COUNT(*) FROM books GROUP BY language ORDER BY COUNT(*) DESC"
+        ).fetchall())
+        return {"total": total, "by_source": by_source, "by_language": by_language}
+
+    # ------------------------------------------------------------------
+    # AudioBookSource adapter
+    # ------------------------------------------------------------------
+
+    def as_source(self) -> "IndexedSource":
+        """Return an AudioBookSource backed by this index."""
+        return IndexedSource(self)
+
+    def __len__(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM books").fetchone()[0]
+
+    def __repr__(self) -> str:
+        return f"BookIndex({self.db_path}, {len(self)} books)"
+
+    def close(self):
+        self._con.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# IndexedSource — drop-in AudioBookSource backed by the index
+# ---------------------------------------------------------------------------
+
+class IndexedSource:
+    """AudioBookSource interface backed by a BookIndex.
+
+    Supports the full search API and can be used anywhere an
+    ``AudioBookSource`` is accepted, including ``sources=`` in
+    ``audiobooker.search()``.
+
+    Parameters
+    ----------
+    index:
+        A ``BookIndex`` instance.
+    source_filter:
+        If set, only return books from this source name.
+    language_filter:
+        If set, only return books with this language code.
+    """
+
+    source_name = "Index"
+
+    def __init__(self, index: BookIndex,
+                 source_filter: Optional[str] = None,
+                 language_filter: Optional[str] = None):
+        self._index = index
+        self._source = source_filter
+        self._language = language_filter
+
+    def iterate_all(self) -> Iterable[AudioBook]:
+        yield from self._index.iterate_all(self._source, self._language)
+
+    def iterate_popular(self) -> Iterable[AudioBook]:
+        return self.iterate_all()
+
+    def iterate_by_author(self, author: str) -> Iterable[AudioBook]:
+        for book in self._index.search_by_author(author, max_results=0):
+            yield book
+
+    def iterate_by_tag(self, tag: str) -> Iterable[AudioBook]:
+        for book in self._index.search_by_tag(tag, max_results=0):
+            yield book
+
+    def search(self, query: str) -> Iterable[AudioBook]:
+        yield from self._index.search(query, max_results=0,
+                                      source=self._source,
+                                      language=self._language)
+
+    def search_by_title(self, query: str) -> Iterable[AudioBook]:
+        yield from self._index.search_by_title(query, max_results=0,
+                                               source=self._source,
+                                               language=self._language)
+
+    def search_by_author(self, query: str) -> Iterable[AudioBook]:
+        yield from self._index.search_by_author(query, max_results=0,
+                                                source=self._source,
+                                                language=self._language)
+
+    def search_by_tag(self, query: str) -> Iterable[AudioBook]:
+        yield from self._index.search_by_tag(query, max_results=0,
+                                             source=self._source,
+                                             language=self._language)
+
+    def search_by_narrator(self, query: str) -> Iterable[AudioBook]:
+        yield from self._index.search_by_narrator(query, max_results=0,
+                                                  source=self._source,
+                                                  language=self._language)
+
+    def __repr__(self) -> str:
+        return f"IndexedSource({self._index!r})"
+
+
+# ---------------------------------------------------------------------------
+# Default sources for build/update (web only, no YouTube)
+# ---------------------------------------------------------------------------
+
+def _default_sources():
+    from audiobooker.scrappers.librivox import Librivox
+    from audiobooker.scrappers.loyalbooks import LoyalBooks
+    from audiobooker.scrappers.goldenaudiobooks import GoldenAudioBooks
+    from audiobooker.scrappers.audioanarchy import AudioAnarchy
+    from audiobooker.scrappers.darkerprojects import DarkerProjects
+    from audiobooker.scrappers.hpaudiotales import HPTalesAudioBooks
+    from audiobooker.scrappers.stephenkingaudiobooks import StephenKingAudioBooks
+    return [
+        Librivox(),
+        LoyalBooks(),
+        StephenKingAudioBooks(),
+        GoldenAudioBooks(),
+        AudioAnarchy(),
+        DarkerProjects(),
+        HPTalesAudioBooks(),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI  (python -m audiobooker.index)
+# ---------------------------------------------------------------------------
+
+_SOURCE_MAP = {
+    "librivox":              "audiobooker.scrappers.librivox.Librivox",
+    "loyalbooks":            "audiobooker.scrappers.loyalbooks.LoyalBooks",
+    "goldenaudiobooks":      "audiobooker.scrappers.goldenaudiobooks.GoldenAudioBooks",
+    "audioanarchy":          "audiobooker.scrappers.audioanarchy.AudioAnarchy",
+    "darkerprojects":        "audiobooker.scrappers.darkerprojects.DarkerProjects",
+    "hpaudiotales":          "audiobooker.scrappers.hpaudiotales.HPTalesAudioBooks",
+    "stephenkingaudiobooks": "audiobooker.scrappers.stephenkingaudiobooks.StephenKingAudioBooks",
+}
+
+
+def _resolve_sources(names):
+    import importlib
+    sources = []
+    for name in names:
+        key = name.lower().replace("-", "").replace("_", "")
+        match = next((v for k, v in _SOURCE_MAP.items()
+                      if k.replace("_", "") == key), None)
+        if not match:
+            print(f"Unknown source: {name!r}. Valid: {', '.join(_SOURCE_MAP)}")
+            continue
+        mod, cls = match.rsplit(".", 1)
+        sources.append(getattr(importlib.import_module(mod), cls)())
+    return sources
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m audiobooker.index",
+        description="Build and query the audiobooker local index.",
+    )
+    parser.add_argument("--db", default=None, help="Path to index database")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_build = sub.add_parser("build", help="(Re)build index for all or selected sources")
+    p_build.add_argument("--sources", nargs="*", help="Sources to index (default: all)")
+
+    p_update = sub.add_parser("update", help="Add new books without clearing existing records")
+    p_update.add_argument("--sources", nargs="*", help="Sources to update (default: all)")
+
+    p_stats = sub.add_parser("stats", help="Show index statistics")
+
+    p_search = sub.add_parser("search", help="Search the index")
+    p_search.add_argument("query")
+    p_search.add_argument("--method", default="search",
+                          choices=["search", "search_by_title", "search_by_author",
+                                   "search_by_tag", "search_by_narrator"])
+    p_search.add_argument("--n", type=int, default=10, help="Max results")
+    p_search.add_argument("--source", default=None, help="Filter by source name")
+
+    args = parser.parse_args()
+
+    idx = BookIndex(args.db)
+
+    if args.cmd == "build":
+        sources = _resolve_sources(args.sources) if args.sources else None
+        print("Building index…")
+        total = idx.build(sources=sources)
+        print(f"Done. {total} books indexed.")
+
+    elif args.cmd == "update":
+        sources = _resolve_sources(args.sources) if args.sources else None
+        print("Updating index…")
+        total = idx.update(sources=sources)
+        print(f"Done. {total} new books added.")
+
+    elif args.cmd == "stats":
+        s = idx.stats()
+        print(f"Total books: {s['total']}")
+        print("\nBy source:")
+        for src, n in s["by_source"].items():
+            print(f"  {src:30s} {n}")
+        print("\nBy language:")
+        for lang, n in s["by_language"].items():
+            print(f"  {lang or '(unknown)':10s} {n}")
+
+    elif args.cmd == "search":
+        fn = getattr(idx, args.method)
+        results = fn(args.query, max_results=args.n,
+                     **({'source': args.source} if args.source else {}))
+        print(f"{len(results)} result(s) for {args.query!r}:\n")
+        for book in results:
+            authors = ", ".join(
+                f"{a.first_name} {a.last_name}".strip() for a in book.authors
+            )
+            print(f"  [{book.score:.2f}] {book.title!r}")
+            print(f"         source={book.source}  author={authors or '?'}"
+                  f"  lang={book.language}  runtime={book.runtime}s")
+    else:
+        parser.print_help()
+
+    idx.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/audiobooker/scrappers/youtube.py
+++ b/audiobooker/scrappers/youtube.py
@@ -316,6 +316,11 @@ class _YtSourceMixin(AudioBookSource):
     min_runtime: int
     narrator: Optional[object]  # AudiobookNarrator or None
     extract_metadata: bool
+    title_blacklist: List[str]  # skip books whose title contains any of these strings
+
+    def _title_blocked(self, title: str) -> bool:
+        tl = title.lower()
+        return any(s.lower() in tl for s in self.title_blacklist)
 
     def _make_book(self, v: dict) -> AudioBook:
         return _video_to_book(
@@ -388,12 +393,16 @@ class YoutubeChannelSource(_YtSourceMixin):
     language: str = "en"
     min_runtime: int = 300
     extract_metadata: bool = True
+    title_blacklist: List[str] = field(default_factory=list)
 
     def iterate_all(self):
         for v in _iter_channel_videos(self.channel_url):
             if _length_to_seconds(v.get("length", "")) < self.min_runtime:
                 continue
-            yield self._tag(self._make_book(v))
+            book = self._make_book(v)
+            if self._title_blocked(book.title):
+                continue
+            yield self._tag(book)
 
 
 @dataclass
@@ -424,12 +433,16 @@ class YoutubePlaylistSource(_YtSourceMixin):
     language: str = "en"
     min_runtime: int = 300
     extract_metadata: bool = True
+    title_blacklist: List[str] = field(default_factory=list)
 
     def iterate_all(self):
         for v in _iter_playlist_videos(self.playlist_url):
             if _length_to_seconds(v.get("length", "")) < self.min_runtime:
                 continue
-            yield self._tag(self._make_book(v))
+            book = self._make_book(v)
+            if self._title_blocked(book.title):
+                continue
+            yield self._tag(book)
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +463,7 @@ class TheCybrarian(YoutubeChannelSource):
             tags=["Fantasy", "Sword and Sorcery", "Robert E. Howard", "Conan"],
             language="en",
             min_runtime=120,
+            title_blacklist=["update"],
         )
 
 

--- a/audiobooker/scrappers/youtube.py
+++ b/audiobooker/scrappers/youtube.py
@@ -156,22 +156,208 @@ def _iter_playlist_videos(playlist_url: str):
                     return
 
 
-def _video_to_book(v: dict, authors: List[BookAuthor],
-                   tags: List[str], language: str) -> AudioBook:
+# ---------------------------------------------------------------------------
+# Metadata extraction from video title + description
+# ---------------------------------------------------------------------------
+
+# "by Author Name", "de Author Name" (Portuguese), "by Author1 and Author2"
+_BY_RE = re.compile(
+    r'\b(?:by|de)\s+([A-Z][a-z.]+(?:\s+[A-Z][a-z.]+){0,3})'
+    r'(?:\s+and\s+([A-Z][a-z.]+(?:\s+[A-Z][a-z.]+){0,3}))?',
+    re.UNICODE,
+)
+# "Narrated by Name", "Read by Name"
+_NARRATOR_RE = re.compile(
+    r'\b(?:narrated|read)\s+by\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})',
+    re.IGNORECASE,
+)
+# Hashtags: #audiobook #horror
+_HASHTAG_RE = re.compile(r'#(\w+)')
+# Year: "published in 1934", "publication in January 1934", "March 1933"
+_YEAR_RE = re.compile(r'\b(1[6-9]\d{2}|20[0-2]\d)\b')
+# Pipe/dash noise suffixes: "| HorrorBabble", "| Clark Ashton Smith's Zothique Cycle",
+# "| A Cthulhu Mythos Story by …", "/ Doctor Satan"
+_NOISE_SUFFIX_RE = re.compile(
+    r'\s*[|/–\-]\s*(?:HorrorBabble|The Cybrarian'
+    r"|[A-Z][a-zA-Z ']+Cycle"
+    r'|(?:A\s+)?(?:Cthulhu Mythos|Doctor Satan|Clean Read).*)',
+    re.IGNORECASE,
+)
+# Bracketed noise: [PREVIEW], [REMASTERED], [English], [unabridged], etc.
+_BRACKET_RE = re.compile(r'\s*\[(?:PREVIEW|REMASTERED|English|Português|unabridged)[^\]]*\]', re.IGNORECASE)
+
+
+def _parse_name(name_str: str):
+    """Split 'First Last' or 'First M. Last' into (first, last)."""
+    parts = name_str.strip().split()
+    if len(parts) == 1:
+        return "", parts[0]
+    return " ".join(parts[:-1]), parts[-1]
+
+
+def extract_yt_metadata(title: str, desc: str) -> dict:
+    """Extract author, narrator, year, tags, and clean title from a video.
+
+    Returns a dict with keys: ``authors``, ``narrator``, ``year``,
+    ``extra_tags``, ``clean_title``.  All values may be empty/None.
+    The caller decides which fields to trust vs override with configured values.
+    """
+    combined = title + "\n" + desc
+
+    # --- authors (search raw combined before noise stripping) ---
+    authors = []
+    m = _BY_RE.search(combined)
+    if m:
+        first, last = _parse_name(m.group(1))
+        authors.append(BookAuthor(first_name=first, last_name=last))
+        if m.group(2):
+            first2, last2 = _parse_name(m.group(2))
+            authors.append(BookAuthor(first_name=first2, last_name=last2))
+
+    # --- narrator ---
+    narrator = None
+    from audiobooker.base import AudiobookNarrator
+    nm = _NARRATOR_RE.search(combined)
+    if nm:
+        first, last = _parse_name(nm.group(1))
+        narrator = AudiobookNarrator(first_name=first, last_name=last)
+
+    # --- year: prefer description (more reliable than title) ---
+    year = 0
+    ym = _YEAR_RE.search(desc) or _YEAR_RE.search(title)
+    if ym:
+        year = int(ym.group(1))
+
+    # --- extra tags from hashtags (deduplicated) ---
+    extra_tags = []
+    _SKIP_HASHTAGS = {"audiobook", "audiolivro", "asmr", "mtg"}
+    seen_tags: set = set()
+    for tag in _HASHTAG_RE.findall(combined.lower()):
+        if tag not in _SKIP_HASHTAGS and len(tag) > 3 and tag not in seen_tags:
+            seen_tags.add(tag)
+            extra_tags.append(tag)
+
+    # --- clean title: strip hashtags, noise suffixes, bracketed labels ---
+    clean = _BRACKET_RE.sub("", title)
+    clean = _NOISE_SUFFIX_RE.sub("", clean)
+    clean = _HASHTAG_RE.sub("", clean).strip(" ,–-|")
+    # collapse multiple spaces
+    clean = re.sub(r'\s{2,}', ' ', clean).strip()
+
+    return {
+        "authors": authors,
+        "narrator": narrator,
+        "year": year,
+        "extra_tags": extra_tags,
+        "clean_title": clean,
+    }
+
+
+def _video_to_book(v: dict, authors: List[BookAuthor], tags: List[str],
+                   language: str, narrator=None,
+                   extract_metadata: bool = True) -> AudioBook:
+    """Build an AudioBook from a raw video dict.
+
+    When ``extract_metadata=True`` (default), author, narrator, year, and
+    extra tags are inferred from the title and description.  Configured
+    ``authors`` and ``narrator`` take precedence: they are only replaced by
+    extracted values when not explicitly set.
+    """
+    from audiobooker.base import AudiobookNarrator
+
+    title = v["title"]
+    desc = v.get("desc", "")
+
+    if extract_metadata:
+        meta = extract_yt_metadata(title, desc)
+        # Use clean title if extraction found something (otherwise keep original)
+        if meta["clean_title"]:
+            title = meta["clean_title"]
+        # Authors: use configured if provided, else fall back to extracted
+        resolved_authors = authors if authors else meta["authors"]
+        # Narrator: use configured if provided, else extracted
+        resolved_narrator = narrator if narrator is not None else meta["narrator"]
+        # Year
+        year = meta["year"]
+        # Merge tags: configured base + hashtag-derived extras (deduplicated)
+        extra_lower = {t.lower() for t in tags}
+        extra_tags = [t for t in meta["extra_tags"] if t not in extra_lower]
+        resolved_tags = tags + extra_tags
+    else:
+        resolved_authors = authors
+        resolved_narrator = narrator
+        year = 0
+        resolved_tags = tags
+
     return AudioBook(
-        title=v["title"],
-        description=v.get("desc", ""),
+        title=title,
+        description=desc,
         image=v.get("thumb", ""),
         streams=[f"https://www.youtube.com/watch?v={v['id']}"],
-        authors=authors,
-        tags=tags,
+        authors=resolved_authors,
+        narrator=resolved_narrator,
+        tags=resolved_tags,
         language=language,
+        year=year,
         runtime=_length_to_seconds(v.get("length", "")),
     )
 
 
+# ---------------------------------------------------------------------------
+# Source base mixin — shared iterate/search for channel and playlist
+# ---------------------------------------------------------------------------
+
+class _YtSourceMixin(AudioBookSource):
+    """Shared search methods for YouTube channel and playlist sources."""
+
+    authors: List[BookAuthor]
+    tags: List[str]
+    language: str
+    min_runtime: int
+    narrator: Optional[object]  # AudiobookNarrator or None
+    extract_metadata: bool
+
+    def _make_book(self, v: dict) -> AudioBook:
+        return _video_to_book(
+            v,
+            authors=self.authors,
+            tags=self.tags,
+            language=self.language,
+            narrator=self.narrator,
+            extract_metadata=self.extract_metadata,
+        )
+
+    def iterate_popular(self):
+        return self.iterate_all()
+
+    def search_by_title(self, query):
+        for b in self.iterate_all():
+            if fuzzy_match(query, b.title):
+                yield b
+
+    def search_by_author(self, query):
+        for b in self.iterate_all():
+            for a in b.authors:
+                full = f"{a.first_name} {a.last_name}".strip()
+                if fuzzy_match(query, full) or fuzzy_match(query, a.last_name):
+                    yield b
+                    break
+
+    def search_by_tag(self, query):
+        for b in self.iterate_all():
+            if any(fuzzy_match(query, t) for t in b.tags):
+                yield b
+
+    def search_by_narrator(self, query):
+        for b in self.iterate_all():
+            if b.narrator:
+                full = f"{b.narrator.first_name} {b.narrator.last_name}".strip()
+                if fuzzy_match(query, full) or fuzzy_match(query, b.narrator.last_name):
+                    yield b
+
+
 @dataclass
-class YoutubeChannelSource(AudioBookSource):
+class YoutubeChannelSource(_YtSourceMixin):
     """Generic AudioBookSource backed by a YouTube channel.
 
     Parameters
@@ -179,102 +365,71 @@ class YoutubeChannelSource(AudioBookSource):
     channel_url:
         Full channel URL, e.g. ``https://www.youtube.com/@HorrorBabble/videos``
     authors:
-        Author list stamped on every yielded AudioBook.
+        Default author list. When ``extract_metadata=True`` and the video title
+        contains a ``by <Name>`` pattern, the extracted author replaces this
+        default only if ``authors`` is empty.
+    narrator:
+        Default narrator. Overridden by ``Narrated by`` extraction only when
+        ``narrator`` is ``None``.
     tags:
-        Tag list stamped on every yielded AudioBook.
+        Base tag list merged with hashtag-derived tags from each video.
     language:
         ISO 639-1 language code (default ``"en"``).
     min_runtime:
-        Skip videos shorter than this many seconds (filters out trailers/shorts).
-        Default 300 (5 minutes).
+        Skip videos shorter than this many seconds (default 300 s / 5 min).
+    extract_metadata:
+        When True (default), infer author, narrator, year, and extra tags
+        from video title and description.
     """
     channel_url: str = ""
     authors: List[BookAuthor] = field(default_factory=list)
+    narrator: Optional[object] = None
     tags: List[str] = field(default_factory=list)
     language: str = "en"
     min_runtime: int = 300
+    extract_metadata: bool = True
 
     def iterate_all(self):
         for v in _iter_channel_videos(self.channel_url):
             if _length_to_seconds(v.get("length", "")) < self.min_runtime:
                 continue
-            book = _video_to_book(v, self.authors, self.tags, self.language)
-            yield self._tag(book)
-
-    def iterate_popular(self):
-        # First page = most recent/featured — good enough as "popular"
-        return self.iterate_all()
-
-    def search_by_title(self, query):
-        for b in self.iterate_all():
-            if fuzzy_match(query, b.title):
-                yield b
-
-    def search_by_author(self, query):
-        for b in self.iterate_all():
-            for a in b.authors:
-                full = f"{a.first_name} {a.last_name}".strip()
-                if fuzzy_match(query, full) or fuzzy_match(query, a.last_name):
-                    yield b
-                    break
-
-    def search_by_tag(self, query):
-        for b in self.iterate_all():
-            if any(fuzzy_match(query, t) for t in b.tags):
-                yield b
+            yield self._tag(self._make_book(v))
 
 
 @dataclass
-class YoutubePlaylistSource(AudioBookSource):
+class YoutubePlaylistSource(_YtSourceMixin):
     """Generic AudioBookSource backed by a YouTube playlist.
 
     Parameters
     ----------
     playlist_url:
-        Full playlist URL, e.g.
-        ``https://www.youtube.com/playlist?list=PLxxxxxx``
+        Full playlist URL, e.g. ``https://www.youtube.com/playlist?list=PLxxxxxx``
     authors:
-        Author list stamped on every yielded AudioBook.
+        Default author list (see ``YoutubeChannelSource.authors``).
+    narrator:
+        Default narrator (see ``YoutubeChannelSource.narrator``).
     tags:
-        Tag list stamped on every yielded AudioBook.
+        Base tag list merged with hashtag-derived tags.
     language:
         ISO 639-1 language code (default ``"en"``).
     min_runtime:
-        Skip videos shorter than this many seconds (default 300 / 5 min).
+        Skip videos shorter than this many seconds (default 300 s / 5 min).
+    extract_metadata:
+        When True (default), infer metadata from title and description.
     """
     playlist_url: str = ""
     authors: List[BookAuthor] = field(default_factory=list)
+    narrator: Optional[object] = None
     tags: List[str] = field(default_factory=list)
     language: str = "en"
     min_runtime: int = 300
+    extract_metadata: bool = True
 
     def iterate_all(self):
         for v in _iter_playlist_videos(self.playlist_url):
             if _length_to_seconds(v.get("length", "")) < self.min_runtime:
                 continue
-            book = _video_to_book(v, self.authors, self.tags, self.language)
-            yield self._tag(book)
-
-    def iterate_popular(self):
-        return self.iterate_all()
-
-    def search_by_title(self, query):
-        for b in self.iterate_all():
-            if fuzzy_match(query, b.title):
-                yield b
-
-    def search_by_author(self, query):
-        for b in self.iterate_all():
-            for a in b.authors:
-                full = f"{a.first_name} {a.last_name}".strip()
-                if fuzzy_match(query, full) or fuzzy_match(query, a.last_name):
-                    yield b
-                    break
-
-    def search_by_tag(self, query):
-        for b in self.iterate_all():
-            if any(fuzzy_match(query, t) for t in b.tags):
-                yield b
+            yield self._tag(self._make_book(v))
 
 
 # ---------------------------------------------------------------------------
@@ -285,22 +440,29 @@ class TheCybrarian(YoutubeChannelSource):
     """Robert E. Howard audiobooks (Conan, Solomon Kane, Kull…) read by The Cybrarian."""
 
     def __init__(self):
+        from audiobooker.base import AudiobookNarrator
         super().__init__(
             channel_url="https://www.youtube.com/@TheCybrarian/videos",
+            # Configured author is the fallback; extraction will override per-video
+            # when a "by <Name>" pattern is found (handles co-authored pieces).
             authors=[BookAuthor(first_name="Robert E.", last_name="Howard")],
+            narrator=AudiobookNarrator(first_name="The", last_name="Cybrarian"),
             tags=["Fantasy", "Sword and Sorcery", "Robert E. Howard", "Conan"],
             language="en",
-            min_runtime=120,  # some shorts are under 5 min; keep anything >2 min
+            min_runtime=120,
         )
 
 
 class HorrorBabble(YoutubeChannelSource):
-    """Horror short fiction audiobooks narrated by Ian Gordon (HorrorBabble)."""
+    """Horror short fiction narrated by Ian Gordon (HorrorBabble)."""
 
     def __init__(self):
+        from audiobooker.base import AudiobookNarrator
         super().__init__(
             channel_url="https://www.youtube.com/@HorrorBabble/videos",
-            authors=[BookAuthor(last_name="Various")],
+            # Authors left empty so extraction fills in per-video author from title
+            authors=[],
+            narrator=AudiobookNarrator(first_name="Ian", last_name="Gordon"),
             tags=["Horror", "Lovecraft", "Weird Fiction", "Short Stories"],
             language="en",
             min_runtime=300,

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,14 @@
 | [scoring.md](scoring.md) | How scores are computed, field weights, fuzzy matching details |
 | [sources.md](sources.md) | Each web scraper — catalogue size, native search, quirks |
 | [youtube.md](youtube.md) | YouTube channel and playlist sources (`YoutubeChannelSource`, `YoutubePlaylistSource`, `TheCybrarian`, `HorrorBabble`) |
+| [index.md](index.md) | `BookIndex` — persistent SQLite index, offline search, CLI |
 | [api.md](api.md) | Full API reference: `AudioBook`, `BookAuthor`, `AudioBookSource`, utilities |
 
 See also the `examples/` directory for runnable code:
 
 | Example | Shows |
 |---|---|
+| `index_usage.py` | Build index, offline search, `IndexedSource` in unified search |
 | `search_all_sources.py` | Unified search across all web sources |
 | `search_librivox.py` | Librivox REST API search |
 | `search_loyalbooks.py` | LoyalBooks genre and title search |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,162 @@
+# Local Index
+
+`BookIndex` stores audiobook records in a local SQLite database so search
+runs instantly without hitting any network after the initial build.
+
+```bash
+pip install audiobooker   # no extra dependencies — uses stdlib sqlite3
+```
+
+## When to use it
+
+| Approach | Speed | Network | Freshness |
+|---|---|---|---|
+| `search()` (live) | slow for linear-scan sources | yes | always fresh |
+| `BookIndex` (indexed) | instant | only during `build()` | stale until refreshed |
+
+Use the index when:
+- You query repeatedly (voice assistant, batch processing)
+- You need offline operation
+- You care about latency (first result in <1ms vs 10–30s)
+
+Don't bother indexing Librivox for interactive use — its REST API is fast enough.
+
+## Build
+
+```python
+from audiobooker.index import BookIndex
+
+idx = BookIndex()                  # stored at ~/.audiobooker/index.db
+idx.build()                        # iterate_all() on all 7 web sources
+idx.build(sources=[Librivox()])    # specific sources only
+```
+
+Build times (single-threaded, cold HTTP cache):
+
+| Source | Books | Time |
+|---|---|---|
+| AudioAnarchy | ~11 | ~1 s |
+| DarkerProjects | ~244 | ~2 min |
+| LoyalBooks | ~3 500 | ~2 min |
+| GoldenAudioBooks | ~6 500 | ~30 min |
+| StephenKingAudioBooks | ~113 | ~1 min |
+| HPTalesAudioBooks | ~20 | ~30 s |
+| Librivox | ~18 000 | ~60 min |
+
+`build()` clears and repopulates records for the given sources. Use `update()`
+to only add new books without clearing existing records.
+
+## Update
+
+```python
+idx.update()                        # add new books from all sources
+idx.update(sources=[Librivox()])    # specific sources only
+```
+
+`update()` uses `AudioBook.__hash__` (title + authors) as the uniqueness key —
+existing books are skipped, new ones are inserted.
+
+## Search
+
+All search methods mirror the live `search*()` API and return results sorted
+by `score` descending, filtered at `min_score=0.45`:
+
+```python
+idx.search("Lovecraft")
+idx.search_by_title("Sherlock Holmes", max_results=5)
+idx.search_by_author("Dickens")
+idx.search_by_tag("horror")
+idx.search_by_narrator("Frank Muller")
+```
+
+Optional filters on any search method:
+
+```python
+# Only books from Librivox
+idx.search_by_tag("horror", source="Librivox")
+
+# Only English books
+idx.search_by_author("Lovecraft", language="en")
+```
+
+## IndexedSource — drop-in for unified search()
+
+`idx.as_source()` returns an `IndexedSource` that implements the full
+`AudioBookSource` interface and can be passed anywhere a source is accepted:
+
+```python
+from audiobooker import search
+from audiobooker.index import BookIndex
+
+idx = BookIndex()
+for book in search("Lovecraft", sources=[idx.as_source()], timeout=5):
+    print(f"[{book.score:.2f}] {book.title}")
+```
+
+Filter by source or language at the `IndexedSource` level:
+
+```python
+from audiobooker.index import IndexedSource
+
+librivox_only = IndexedSource(idx, source_filter="Librivox")
+english_only  = IndexedSource(idx, language_filter="en")
+```
+
+## Stats
+
+```python
+s = idx.stats()
+# {'total': 28388, 'by_source': {'Librivox': 18012, ...}, 'by_language': {'en': 26400, ...}}
+print(len(idx))   # total book count
+```
+
+## CLI
+
+```bash
+# Build full index (all sources)
+python -m audiobooker.index build
+
+# Build selected sources
+python -m audiobooker.index build --sources librivox loyalbooks
+
+# Add new books without clearing existing records
+python -m audiobooker.index update
+
+# Show stats
+python -m audiobooker.index stats
+
+# Search
+python -m audiobooker.index search "Lovecraft"
+python -m audiobooker.index search "Conan" --method search_by_title --n 5
+python -m audiobooker.index search "horror" --method search_by_tag --source Librivox
+
+# Custom database path
+python -m audiobooker.index --db /data/books.db build
+```
+
+## Custom database path
+
+```python
+idx = BookIndex("/data/my_books.db")
+```
+
+Or as a context manager:
+
+```python
+with BookIndex() as idx:
+    idx.build(sources=[AudioAnarchy()])
+    for book in idx.search("anarchy"):
+        print(book.title)
+```
+
+## YouTube sources and the index
+
+YouTube channels change frequently (new uploads). They are excluded from the
+default `build()` source list. You can index them explicitly, but `update()`
+is better suited — run it periodically to pick up new videos:
+
+```python
+from audiobooker.scrappers.youtube import HorrorBabble, TheCybrarian
+
+idx.update(sources=[HorrorBabble(), TheCybrarian()])
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,7 @@ python -m audiobooker.index build
 # Build selected sources
 python -m audiobooker.index build --sources librivox loyalbooks
 
-# Incremental update
+# Incremental update (includes followed YouTube sources automatically)
 python -m audiobooker.index update
 python -m audiobooker.index update --sources librivox
 
@@ -158,9 +158,22 @@ python -m audiobooker.index search "Conan" --method search_by_title --n 5
 python -m audiobooker.index search "horror" --method search_by_tag --source Librivox
 python -m audiobooker.index search "Wayne June" --method search_by_narrator
 
+# Follow a YouTube channel or playlist
+python -m audiobooker.index follow https://www.youtube.com/@HorrorBabble/videos \
+    --kind channel --name HorrorBabble --tags Horror "Weird Fiction"
+python -m audiobooker.index follow https://www.youtube.com/playlist?list=PLxxx \
+    --kind playlist --name "My Playlist" --blacklist update compilation
+
+# List followed sources
+python -m audiobooker.index list
+
+# Unfollow
+python -m audiobooker.index unfollow https://www.youtube.com/@HorrorBabble/videos
+
 # Custom database path
 python -m audiobooker.index --db /data/books.db build
 python -m audiobooker.index --db /data/books.db search "Poe"
+python -m audiobooker.index --db /data/books.db follow https://www.youtube.com/@Test/videos
 ```
 
 ## Custom database path
@@ -178,10 +191,79 @@ with BookIndex() as idx:
         print(book.title)
 ```
 
-## YouTube sources
+## Following YouTube channels and playlists
+
+Register channels or playlists so they are automatically included in `update()`
+without having to name them every time. Third-party consumers of your index get
+the same videos automatically.
+
+```python
+from audiobooker.base import AudiobookNarrator
+
+# Follow a channel
+idx.follow(
+    "https://www.youtube.com/@HorrorBabble/videos",
+    kind="channel",
+    name="HorrorBabble",
+    tags=["Horror", "Weird Fiction"],
+    language="en",
+    min_runtime=300,
+    title_blacklist=["compilation", "update"],  # skip non-audiobook videos
+)
+
+# Follow a playlist
+idx.follow(
+    "https://www.youtube.com/playlist?list=PLxxxxxx",
+    kind="playlist",
+    name="My Audiobook Playlist",
+)
+
+# Inspect followed sources
+for f in idx.list_followed():
+    print(f["kind"], f["name"] or f["url"])
+
+# Remove a followed source
+idx.unfollow("https://www.youtube.com/@HorrorBabble/videos")
+
+# update() with no args now includes followed sources automatically
+idx.update()
+```
+
+### Title blacklist
+
+Use `title_blacklist` to skip videos whose title contains specific strings
+(case-insensitive). Useful for filtering out channel-update videos, compilations,
+or other non-audiobook content. `TheCybrarian` ships with `["update"]` by default.
+
+```python
+idx.follow(url, title_blacklist=["update", "live stream", "q&a"])
+```
+
+### CLI
+
+```bash
+# Follow a channel
+python -m audiobooker.index follow https://www.youtube.com/@HorrorBabble/videos \
+    --kind channel --name HorrorBabble --tags Horror "Weird Fiction" --language en
+
+# Follow with a title blacklist
+python -m audiobooker.index follow https://www.youtube.com/@TheCybrarian/videos \
+    --blacklist update compilation
+
+# List followed sources
+python -m audiobooker.index list
+
+# Unfollow
+python -m audiobooker.index unfollow https://www.youtube.com/@HorrorBabble/videos
+
+# update() now includes followed sources
+python -m audiobooker.index update
+```
+
+## YouTube sources (built-in)
 
 YouTube channels are excluded from the default `build()` source list since
-they update frequently. Use `update()` to add new videos periodically:
+they update frequently. Use `update()` or `follow()` to add them periodically:
 
 ```python
 from audiobooker.scrappers.youtube import HorrorBabble, TheCybrarian

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,22 @@ pip install audiobooker   # no extra dependencies — uses stdlib sqlite3
 Use the index when:
 - You query repeatedly (voice assistant, batch processing)
 - You need offline operation
-- You care about latency (first result in <1ms vs 10–30s)
+- You care about latency (first result in <20ms vs 10–30s)
 
-Don't bother indexing Librivox for interactive use — its REST API is fast enough.
+## Search strategy
+
+Two-phase: **FTS5 pre-filter → rapidfuzz re-rank**.
+
+1. SQLite FTS5 tokenises the query into prefix terms (`"love"*`) and
+   applies an OR across tokens. This runs in C against an inverted index
+   and returns up to 500 candidates in microseconds.
+2. rapidfuzz WRatio re-ranks the candidate shortlist with full fuzzy
+   scoring including typo handling, token reordering, and containment bonuses.
+3. If FTS returns fewer than 5 hits (e.g. a misspelled query), the search
+   automatically falls back to a full rapidfuzz scan of all rows — so typos
+   never produce zero results, they just take a bit longer (~50–100ms at 18k books).
+
+Typical query latency: **~15ms** (FTS path) vs O(N·WRatio) without an index.
 
 ## Build
 
@@ -31,20 +44,20 @@ idx.build()                        # iterate_all() on all 7 web sources
 idx.build(sources=[Librivox()])    # specific sources only
 ```
 
+`build()` clears and repopulates records for the given sources, then
+rebuilds the FTS index. Use `update()` to only add new books.
+
 Build times (single-threaded, cold HTTP cache):
 
 | Source | Books | Time |
 |---|---|---|
 | AudioAnarchy | ~11 | ~1 s |
+| HPTalesAudioBooks | ~20 | ~30 s |
+| StephenKingAudioBooks | ~113 | ~1 min |
 | DarkerProjects | ~244 | ~2 min |
 | LoyalBooks | ~3 500 | ~2 min |
 | GoldenAudioBooks | ~6 500 | ~30 min |
-| StephenKingAudioBooks | ~113 | ~1 min |
-| HPTalesAudioBooks | ~20 | ~30 s |
 | Librivox | ~18 000 | ~60 min |
-
-`build()` clears and repopulates records for the given sources. Use `update()`
-to only add new books without clearing existing records.
 
 ## Update
 
@@ -53,40 +66,52 @@ idx.update()                        # add new books from all sources
 idx.update(sources=[Librivox()])    # specific sources only
 ```
 
-`update()` uses `AudioBook.__hash__` (title + authors) as the uniqueness key —
-existing books are skipped, new ones are inserted.
+`update()` uses `AudioBook.__hash__` (title + authors) as the uniqueness key.
+Existing books are skipped; new ones are inserted and the FTS index is
+updated incrementally (no full rebuild needed).
 
 ## Search
 
-All search methods mirror the live `search*()` API and return results sorted
-by `score` descending, filtered at `min_score=0.45`:
+All methods return results sorted by `score` descending, filtered at
+`min_score=0.45`. Books without a narrator are automatically excluded from
+`search_by_narrator`.
 
 ```python
-idx.search("Lovecraft")
+idx.search("Lovecraft")                         # all fields, weighted
 idx.search_by_title("Sherlock Holmes", max_results=5)
 idx.search_by_author("Dickens")
-idx.search_by_tag("horror")
+idx.search_by_tag("Horror")
 idx.search_by_narrator("Frank Muller")
 ```
 
-Optional filters on any search method:
+### Scoring note
+
+`search()` weights: title 55%, author 30%, tag 10%, narrator 5%. A single
+genre word like "Horror" scores ~0.35 in a general search — below the 0.45
+threshold. Use `search_by_tag("Horror")` when you want genre results.
+
+### Optional filters
 
 ```python
-# Only books from Librivox
-idx.search_by_tag("horror", source="Librivox")
+idx.search_by_tag("Horror", source="Librivox")     # source filter
+idx.search_by_author("Lovecraft", language="en")   # language filter
+idx.search_by_title("Faust", max_results=3, min_score=0.6)
+```
 
-# Only English books
-idx.search_by_author("Lovecraft", language="en")
+### Typo tolerance
+
+FTS5 handles prefix matching but not typos. When FTS returns < 5 hits,
+the search automatically falls back to a full rapidfuzz scan:
+
+```python
+idx.search_by_title("Sherlok Holms")  # FTS misses, rapidfuzz finds it
 ```
 
 ## IndexedSource — drop-in for unified search()
 
-`idx.as_source()` returns an `IndexedSource` that implements the full
-`AudioBookSource` interface and can be passed anywhere a source is accepted:
-
 ```python
 from audiobooker import search
-from audiobooker.index import BookIndex
+from audiobooker.index import BookIndex, IndexedSource
 
 idx = BookIndex()
 for book in search("Lovecraft", sources=[idx.as_source()], timeout=5):
@@ -96,10 +121,11 @@ for book in search("Lovecraft", sources=[idx.as_source()], timeout=5):
 Filter by source or language at the `IndexedSource` level:
 
 ```python
-from audiobooker.index import IndexedSource
-
 librivox_only = IndexedSource(idx, source_filter="Librivox")
 english_only  = IndexedSource(idx, language_filter="en")
+
+for book in search("horror", sources=[english_only], timeout=5):
+    print(book.title)
 ```
 
 ## Stats
@@ -113,25 +139,28 @@ print(len(idx))   # total book count
 ## CLI
 
 ```bash
-# Build full index (all sources)
+# Build full index
 python -m audiobooker.index build
 
 # Build selected sources
 python -m audiobooker.index build --sources librivox loyalbooks
 
-# Add new books without clearing existing records
+# Incremental update
 python -m audiobooker.index update
+python -m audiobooker.index update --sources librivox
 
-# Show stats
+# Stats
 python -m audiobooker.index stats
 
 # Search
 python -m audiobooker.index search "Lovecraft"
 python -m audiobooker.index search "Conan" --method search_by_title --n 5
 python -m audiobooker.index search "horror" --method search_by_tag --source Librivox
+python -m audiobooker.index search "Wayne June" --method search_by_narrator
 
 # Custom database path
 python -m audiobooker.index --db /data/books.db build
+python -m audiobooker.index --db /data/books.db search "Poe"
 ```
 
 ## Custom database path
@@ -140,7 +169,7 @@ python -m audiobooker.index --db /data/books.db build
 idx = BookIndex("/data/my_books.db")
 ```
 
-Or as a context manager:
+## Context manager
 
 ```python
 with BookIndex() as idx:
@@ -149,14 +178,25 @@ with BookIndex() as idx:
         print(book.title)
 ```
 
-## YouTube sources and the index
+## YouTube sources
 
-YouTube channels change frequently (new uploads). They are excluded from the
-default `build()` source list. You can index them explicitly, but `update()`
-is better suited — run it periodically to pick up new videos:
+YouTube channels are excluded from the default `build()` source list since
+they update frequently. Use `update()` to add new videos periodically:
 
 ```python
 from audiobooker.scrappers.youtube import HorrorBabble, TheCybrarian
 
 idx.update(sources=[HorrorBabble(), TheCybrarian()])
 ```
+
+## Schema
+
+The SQLite database has two tables:
+
+- **`books`** — one row per book; primary key is an auto-increment `id`;
+  `hash` (title + authors) is a unique constraint used for deduplication;
+  `authors_text`, `tags_text`, `narrator_text` are flattened plaintext copies
+  of the JSON fields used for FTS indexing.
+- **`books_fts`** — FTS5 virtual table (unicode61 tokeniser, diacritic removal)
+  linked to `books.id`. Kept in sync via explicit insert/delete calls during
+  `build()` and `update()`.

--- a/examples/index_usage.py
+++ b/examples/index_usage.py
@@ -1,75 +1,106 @@
 """Local index — build once, search instantly without network.
 
-Run this script once to build the index, then use it for offline search.
 The index is stored in ~/.audiobooker/index.db by default.
 
-Build time estimates (single-threaded, cold cache):
-  AudioAnarchy    ~1s      (~11 books)
-  LoyalBooks      ~2 min   (~3 500 books)
-  DarkerProjects  ~2 min   (~244 books)
-  GoldenAudioBooks ~30 min  (~6 500 books)
-  Librivox        ~60 min  (~18 000 books, REST-paged)
+Build time estimates (single-threaded, cold HTTP cache):
+  AudioAnarchy         ~1 s      (~11 books)
+  DarkerProjects       ~2 min    (~244 books)
+  LoyalBooks           ~2 min    (~3 500 books)
+  StephenKingAudioBooks ~1 min   (~113 books)
+  HPTalesAudioBooks    ~30 s     (~20 books)
+  GoldenAudioBooks     ~30 min   (~6 500 books)
+  Librivox             ~60 min   (~18 000 books, REST-paged)
+
+Run:
+  python examples/index_usage.py
+  python -m audiobooker.index build --sources librivox loyalbooks
+  python -m audiobooker.index search "Lovecraft" --method search_by_author
 """
 import time
-from audiobooker.index import BookIndex
+from audiobooker.index import BookIndex, IndexedSource
 from audiobooker.scrappers.audioanarchy import AudioAnarchy
-from audiobooker.scrappers.darkerprojects import DarkerProjects
 from audiobooker import search
 
 # ---------------------------------------------------------------------------
-# 1. Build index from fast/small sources for this demo
+# 1. Build index — small source so this demo runs fast
 # ---------------------------------------------------------------------------
-idx = BookIndex()  # ~/.audiobooker/index.db
+idx = BookIndex()   # ~/.audiobooker/index.db
 
-print("=== Building index (AudioAnarchy + DarkerProjects) ===\n")
-idx.build(sources=[AudioAnarchy(), DarkerProjects()])
+print("=== Building index (AudioAnarchy) ===\n")
+idx.build(sources=[AudioAnarchy()])
 print()
 
 # ---------------------------------------------------------------------------
 # 2. Stats
 # ---------------------------------------------------------------------------
 s = idx.stats()
-print(f"=== Index stats: {s['total']} books ===")
+print(f"Total books: {s['total']}")
 for src, n in s["by_source"].items():
     print(f"  {src}: {n}")
 print()
 
 # ---------------------------------------------------------------------------
-# 3. Offline search — no network after build
+# 3. Search methods — all run offline after build
 # ---------------------------------------------------------------------------
-print('=== search("drama") — offline, instant ===\n')
+def show(label, results, limit=3):
+    print(f"{label}  ({len(results)} hit(s))")
+    for b in results[:limit]:
+        authors = ", ".join(f"{a.first_name} {a.last_name}".strip()
+                            for a in b.authors)
+        print(f"  [{b.score:.2f}] {b.title!r}  tags={b.tags}")
+    print()
+
 t0 = time.monotonic()
-for book in idx.search("drama", max_results=5):
-    authors = ", ".join(f"{a.first_name} {a.last_name}".strip() for a in book.authors)
-    print(f"  [{book.score:.2f}] {book.title!r}")
-    print(f"         source={book.source}  tags={book.tags}")
-print(f"\nDone in {time.monotonic() - t0:.3f}s\n")
+show('search_by_tag("radio")',    idx.search_by_tag("radio"))
+show('search_by_tag("anarchy")', idx.search_by_tag("anarchy"))
+show('search_by_title("introduction")', idx.search_by_title("introduction"))
+show('search("democracy")',       idx.search("democracy"))
+print(f"All searches completed in {(time.monotonic() - t0)*1000:.1f}ms\n")
 
 # ---------------------------------------------------------------------------
-# 4. IndexedSource as drop-in for unified search()
+# 4. Typo tolerance — FTS misses, rapidfuzz full-scan fallback kicks in
 # ---------------------------------------------------------------------------
-print('=== search("anarchy", sources=[idx.as_source()]) ===\n')
+print("=== Typo tolerance ===\n")
+t0 = time.monotonic()
+results = idx.search_by_title("anarchi")   # typo
+ms = (time.monotonic() - t0) * 1000
+show(f'search_by_title("anarchi") [typo, {ms:.1f}ms]', results)
+
+# ---------------------------------------------------------------------------
+# 5. IndexedSource — drop-in for unified search()
+# ---------------------------------------------------------------------------
+print("=== IndexedSource in unified search() ===\n")
 t0 = time.monotonic()
 for book in search("anarchy", sources=[idx.as_source()], timeout=5):
-    print(f"  [{book.score:.2f}] {book.title!r}  tags={book.tags}")
-print(f"\nDone in {time.monotonic() - t0:.3f}s\n")
+    print(f"  [{book.score:.2f}] [{book.source}] {book.title!r}")
+print(f"\nDone in {(time.monotonic() - t0)*1000:.1f}ms\n")
 
 # ---------------------------------------------------------------------------
-# 5. Update — only add new books (skips existing by title+author hash)
+# 6. Source and language filters
 # ---------------------------------------------------------------------------
-print("=== update() — adds only new books ===\n")
-added = idx.update(sources=[AudioAnarchy()])
-print(f"  {added} new books added\n")
+print("=== Filtered IndexedSource ===\n")
+audio_only = IndexedSource(idx, source_filter="AudioAnarchy")
+en_only    = IndexedSource(idx, language_filter="en")
+print(f"AudioAnarchy only: {sum(1 for _ in audio_only.iterate_all())} books")
+print(f"English only:      {sum(1 for _ in en_only.iterate_all())} books\n")
+
+# ---------------------------------------------------------------------------
+# 7. Update — adds only new books, skips existing
+# ---------------------------------------------------------------------------
+print("=== update() — incremental, skips duplicates ===\n")
+added = idx.update(sources=[AudioAnarchy()], progress=True)
+print(f"\n{added} new books added (0 expected — already indexed)\n")
 
 idx.close()
 
 # ---------------------------------------------------------------------------
-# 6. CLI reminder
+# 8. CLI quick-reference
 # ---------------------------------------------------------------------------
-print("CLI usage:")
+print("CLI:")
 print("  python -m audiobooker.index build")
 print("  python -m audiobooker.index build --sources librivox loyalbooks")
-print("  python -m audiobooker.index update")
+print("  python -m audiobooker.index update --sources librivox")
 print("  python -m audiobooker.index stats")
-print('  python -m audiobooker.index search "Lovecraft"')
-print('  python -m audiobooker.index search "Conan" --method search_by_title --n 5')
+print('  python -m audiobooker.index search "Lovecraft" --method search_by_author')
+print('  python -m audiobooker.index search "horror" --method search_by_tag --n 5')
+print("  python -m audiobooker.index --db /data/books.db stats")

--- a/examples/index_usage.py
+++ b/examples/index_usage.py
@@ -1,0 +1,75 @@
+"""Local index — build once, search instantly without network.
+
+Run this script once to build the index, then use it for offline search.
+The index is stored in ~/.audiobooker/index.db by default.
+
+Build time estimates (single-threaded, cold cache):
+  AudioAnarchy    ~1s      (~11 books)
+  LoyalBooks      ~2 min   (~3 500 books)
+  DarkerProjects  ~2 min   (~244 books)
+  GoldenAudioBooks ~30 min  (~6 500 books)
+  Librivox        ~60 min  (~18 000 books, REST-paged)
+"""
+import time
+from audiobooker.index import BookIndex
+from audiobooker.scrappers.audioanarchy import AudioAnarchy
+from audiobooker.scrappers.darkerprojects import DarkerProjects
+from audiobooker import search
+
+# ---------------------------------------------------------------------------
+# 1. Build index from fast/small sources for this demo
+# ---------------------------------------------------------------------------
+idx = BookIndex()  # ~/.audiobooker/index.db
+
+print("=== Building index (AudioAnarchy + DarkerProjects) ===\n")
+idx.build(sources=[AudioAnarchy(), DarkerProjects()])
+print()
+
+# ---------------------------------------------------------------------------
+# 2. Stats
+# ---------------------------------------------------------------------------
+s = idx.stats()
+print(f"=== Index stats: {s['total']} books ===")
+for src, n in s["by_source"].items():
+    print(f"  {src}: {n}")
+print()
+
+# ---------------------------------------------------------------------------
+# 3. Offline search — no network after build
+# ---------------------------------------------------------------------------
+print('=== search("drama") — offline, instant ===\n')
+t0 = time.monotonic()
+for book in idx.search("drama", max_results=5):
+    authors = ", ".join(f"{a.first_name} {a.last_name}".strip() for a in book.authors)
+    print(f"  [{book.score:.2f}] {book.title!r}")
+    print(f"         source={book.source}  tags={book.tags}")
+print(f"\nDone in {time.monotonic() - t0:.3f}s\n")
+
+# ---------------------------------------------------------------------------
+# 4. IndexedSource as drop-in for unified search()
+# ---------------------------------------------------------------------------
+print('=== search("anarchy", sources=[idx.as_source()]) ===\n')
+t0 = time.monotonic()
+for book in search("anarchy", sources=[idx.as_source()], timeout=5):
+    print(f"  [{book.score:.2f}] {book.title!r}  tags={book.tags}")
+print(f"\nDone in {time.monotonic() - t0:.3f}s\n")
+
+# ---------------------------------------------------------------------------
+# 5. Update — only add new books (skips existing by title+author hash)
+# ---------------------------------------------------------------------------
+print("=== update() — adds only new books ===\n")
+added = idx.update(sources=[AudioAnarchy()])
+print(f"  {added} new books added\n")
+
+idx.close()
+
+# ---------------------------------------------------------------------------
+# 6. CLI reminder
+# ---------------------------------------------------------------------------
+print("CLI usage:")
+print("  python -m audiobooker.index build")
+print("  python -m audiobooker.index build --sources librivox loyalbooks")
+print("  python -m audiobooker.index update")
+print("  python -m audiobooker.index stats")
+print('  python -m audiobooker.index search "Lovecraft"')
+print('  python -m audiobooker.index search "Conan" --method search_by_title --n 5')

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -455,5 +455,70 @@ class TestIndexedSource(unittest.TestCase):
         self.assertIn("BookIndex", repr(self.src))
 
 
+# ---------------------------------------------------------------------------
+# BookIndex — follow / unfollow / list_followed
+# ---------------------------------------------------------------------------
+
+class TestFollowedSources(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index([])  # empty index
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_follow_adds_entry(self):
+        self.idx.follow("https://www.youtube.com/@Test/videos", kind="channel",
+                        name="Test Channel", tags=["Horror"], language="en")
+        followed = self.idx.list_followed()
+        self.assertEqual(len(followed), 1)
+        self.assertEqual(followed[0]["url"], "https://www.youtube.com/@Test/videos")
+        self.assertEqual(followed[0]["kind"], "channel")
+        self.assertEqual(followed[0]["name"], "Test Channel")
+        self.assertEqual(followed[0]["tags"], ["Horror"])
+        self.assertEqual(followed[0]["language"], "en")
+
+    def test_follow_playlist(self):
+        self.idx.follow("https://www.youtube.com/playlist?list=PLabc",
+                        kind="playlist", name="My Playlist")
+        followed = self.idx.list_followed()
+        self.assertEqual(followed[0]["kind"], "playlist")
+
+    def test_follow_upserts_on_duplicate_url(self):
+        url = "https://www.youtube.com/@Test/videos"
+        self.idx.follow(url, name="Old Name")
+        self.idx.follow(url, name="New Name")
+        followed = self.idx.list_followed()
+        self.assertEqual(len(followed), 1)
+        self.assertEqual(followed[0]["name"], "New Name")
+
+    def test_unfollow_removes_entry(self):
+        url = "https://www.youtube.com/@Test/videos"
+        self.idx.follow(url)
+        removed = self.idx.unfollow(url)
+        self.assertTrue(removed)
+        self.assertEqual(self.idx.list_followed(), [])
+
+    def test_unfollow_returns_false_when_missing(self):
+        removed = self.idx.unfollow("https://www.youtube.com/@nonexistent/videos")
+        self.assertFalse(removed)
+
+    def test_follow_with_blacklist(self):
+        self.idx.follow("https://www.youtube.com/@Test/videos",
+                        title_blacklist=["update", "compilation"])
+        followed = self.idx.list_followed()
+        self.assertEqual(followed[0]["title_blacklist"], ["update", "compilation"])
+
+    def test_list_followed_empty(self):
+        self.assertEqual(self.idx.list_followed(), [])
+
+    def test_follow_with_narrator(self):
+        from audiobooker.base import AudiobookNarrator
+        n = AudiobookNarrator(first_name="Wayne", last_name="June")
+        self.idx.follow("https://www.youtube.com/@Test/videos", narrator=n)
+        followed = self.idx.list_followed()
+        self.assertEqual(followed[0]["narrator"]["last_name"], "June")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_index.py
+++ b/test/test_index.py
@@ -1,0 +1,459 @@
+"""Tests for audiobooker.index — BookIndex and IndexedSource."""
+import tempfile
+import unittest
+from pathlib import Path
+
+from audiobooker.base import AudioBook, BookAuthor, AudiobookNarrator
+from audiobooker.index import BookIndex, IndexedSource, _fts_query
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _book(title, authors=None, tags=None, narrator=None,
+          source="TestSource", language="en", year=0, runtime=0):
+    return AudioBook(
+        title=title,
+        authors=authors or [],
+        tags=tags or [],
+        narrator=narrator,
+        source=source,
+        language=language,
+        year=year,
+        runtime=runtime,
+        streams=["http://example.com/book.mp3"],
+    )
+
+
+LOVECRAFT = _book(
+    "The Call of Cthulhu",
+    authors=[BookAuthor(first_name="H. P.", last_name="Lovecraft")],
+    tags=["Horror", "Weird Fiction"],
+    narrator=AudiobookNarrator(first_name="Wayne", last_name="June"),
+    year=1926, runtime=3600,
+)
+DOYLE = _book(
+    "The Hound of the Baskervilles",
+    authors=[BookAuthor(first_name="Arthur Conan", last_name="Doyle")],
+    tags=["Mystery", "Detective"],
+    year=1902, runtime=7200,
+)
+DICKENS = _book(
+    "A Tale of Two Cities",
+    authors=[BookAuthor(first_name="Charles", last_name="Dickens")],
+    tags=["Historical Fiction", "Classic"],
+    year=1859, runtime=54000,
+)
+KING = _book(
+    "The Shining",
+    authors=[BookAuthor(first_name="Stephen", last_name="King")],
+    tags=["Horror", "Thriller"],
+    narrator=AudiobookNarrator(first_name="Campbell", last_name="Scott"),
+    year=1977, runtime=14400,
+    source="StephenKingAudioBooks",
+)
+TOLKIEN = _book(
+    "The Fellowship of the Ring",
+    authors=[BookAuthor(first_name="J.R.R.", last_name="Tolkien")],
+    tags=["Fantasy", "Epic"],
+    year=1954, runtime=28800,
+)
+GERMAN_BOOK = _book(
+    "Faust",
+    authors=[BookAuthor(first_name="Johann Wolfgang von", last_name="Goethe")],
+    tags=["Classic", "Drama"],
+    language="de", year=1808,
+)
+
+ALL_BOOKS = [LOVECRAFT, DOYLE, DICKENS, KING, TOLKIEN, GERMAN_BOOK]
+
+
+def _make_index(books=None) -> BookIndex:
+    """Create a temporary in-memory index pre-populated with test books."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    idx = BookIndex(tmp.name)
+    for book in (books or ALL_BOOKS):
+        idx._upsert(book)
+    idx._con.commit()
+    idx._fts_rebuild()
+    return idx
+
+
+# ---------------------------------------------------------------------------
+# FTS query builder
+# ---------------------------------------------------------------------------
+
+class TestFtsQuery(unittest.TestCase):
+
+    def test_single_word_prefix(self):
+        q = _fts_query("love")
+        self.assertIn('"love"*', q)
+
+    def test_multi_word_or(self):
+        q = _fts_query("sherlock holmes")
+        self.assertIn('"sherlock"*', q)
+        self.assertIn('"holmes"*', q)
+        self.assertIn(" OR ", q)
+
+    def test_field_restriction(self):
+        q = _fts_query("horror", field="tags_text")
+        self.assertTrue(q.startswith("tags_text:"))
+
+    def test_strips_punctuation(self):
+        q = _fts_query("lovecraft,")
+        self.assertIn('"lovecraft"*', q)
+        self.assertNotIn(",", q)
+
+    def test_empty_query(self):
+        q = _fts_query("")
+        self.assertEqual(q, '""')
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — building
+# ---------------------------------------------------------------------------
+
+class TestBookIndexBuild(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_len(self):
+        self.assertEqual(len(self.idx), len(ALL_BOOKS))
+
+    def test_stats_total(self):
+        s = self.idx.stats()
+        self.assertEqual(s["total"], len(ALL_BOOKS))
+
+    def test_stats_by_source(self):
+        s = self.idx.stats()
+        self.assertIn("TestSource", s["by_source"])
+        self.assertIn("StephenKingAudioBooks", s["by_source"])
+
+    def test_stats_by_language(self):
+        s = self.idx.stats()
+        self.assertIn("en", s["by_language"])
+        self.assertIn("de", s["by_language"])
+
+    def test_iterate_all(self):
+        books = list(self.idx.iterate_all())
+        self.assertEqual(len(books), len(ALL_BOOKS))
+
+    def test_iterate_all_source_filter(self):
+        books = list(self.idx.iterate_all(source="StephenKingAudioBooks"))
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0].title, "The Shining")
+
+    def test_iterate_all_language_filter(self):
+        books = list(self.idx.iterate_all(language="de"))
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0].title, "Faust")
+
+    def test_roundtrip_fields(self):
+        books = {b.title: b for b in self.idx.iterate_all()}
+        b = books["The Call of Cthulhu"]
+        self.assertEqual(b.authors[0].last_name, "Lovecraft")
+        self.assertEqual(b.narrator.last_name, "June")
+        self.assertEqual(b.year, 1926)
+        self.assertEqual(b.runtime, 3600)
+        self.assertEqual(b.language, "en")
+        self.assertEqual(b.tags, ["Horror", "Weird Fiction"])
+        self.assertEqual(b.streams, ["http://example.com/book.mp3"])
+
+    def test_build_clears_source(self):
+        """build() for a source replaces its existing records."""
+        new_book = _book("New Book", source="TestSource")
+        self.idx._upsert(new_book)
+        self.idx._con.commit()
+        self.idx._fts_rebuild()
+        # build with a fake source that yields only one book
+        class _FakeSource:
+            __class__ = type("TestSource", (), {"__name__": "TestSource"})()
+            def iterate_all(self_):
+                yield LOVECRAFT
+        self.idx.build(sources=[_FakeSource()], progress=False)
+        books = list(self.idx.iterate_all(source="TestSource"))
+        self.assertEqual(len(books), 1)
+
+    def test_context_manager(self):
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.close()
+        with BookIndex(tmp.name) as idx:
+            idx._upsert(LOVECRAFT)
+            idx._con.commit()
+            idx._fts_rebuild()
+            self.assertEqual(len(idx), 1)
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — update / deduplication
+# ---------------------------------------------------------------------------
+
+class TestBookIndexUpdate(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index([LOVECRAFT, DOYLE])
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_update_adds_new(self):
+        class _Src:
+            __class__ = type("TestSource", (), {"__name__": "TestSource"})()
+            def iterate_all(self_):
+                yield DICKENS
+        added = self.idx.update(sources=[_Src()], progress=False)
+        self.assertEqual(added, 1)
+        self.assertEqual(len(self.idx), 3)
+
+    def test_update_skips_existing(self):
+        class _Src:
+            __class__ = type("TestSource", (), {"__name__": "TestSource"})()
+            def iterate_all(self_):
+                yield LOVECRAFT   # already present
+                yield DICKENS     # new
+        added = self.idx.update(sources=[_Src()], progress=False)
+        self.assertEqual(added, 1)
+
+    def test_duplicate_hash_not_double_inserted(self):
+        self.idx._upsert(LOVECRAFT)  # same hash — INSERT OR REPLACE
+        self.idx._con.commit()
+        self.idx._fts_rebuild()
+        self.assertEqual(len(self.idx), 2)  # still 2, not 3
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — search_by_title
+# ---------------------------------------------------------------------------
+
+class TestSearchByTitle(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_exact_match(self):
+        results = self.idx.search_by_title("The Shining")
+        self.assertTrue(any(b.title == "The Shining" for b in results))
+
+    def test_partial_word(self):
+        results = self.idx.search_by_title("Cthulhu")
+        self.assertTrue(any("Cthulhu" in b.title for b in results))
+
+    def test_scores_sorted(self):
+        results = self.idx.search_by_title("The Shining")
+        scores = [b.score for b in results]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_max_results(self):
+        results = self.idx.search_by_title("the", max_results=2)
+        self.assertLessEqual(len(results), 2)
+
+    def test_min_score_filters(self):
+        results = self.idx.search_by_title("xyz_no_match", min_score=0.45)
+        self.assertEqual(results, [])
+
+    def test_typo_fallback(self):
+        # "Shinng" — FTS won't match prefix, should fall back to rapidfuzz
+        results = self.idx.search_by_title("The Shinng", min_score=0.5)
+        self.assertTrue(any("Shining" in b.title for b in results))
+
+    def test_source_filter(self):
+        results = self.idx.search_by_title("The Shining",
+                                           source="StephenKingAudioBooks")
+        self.assertTrue(all(b.source == "StephenKingAudioBooks" for b in results))
+
+    def test_language_filter_excludes(self):
+        results = self.idx.search_by_title("Faust", language="en")
+        self.assertFalse(any(b.title == "Faust" for b in results))
+
+    def test_language_filter_includes(self):
+        results = self.idx.search_by_title("Faust", language="de",
+                                           min_score=0.5)
+        self.assertTrue(any(b.title == "Faust" for b in results))
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — search_by_author
+# ---------------------------------------------------------------------------
+
+class TestSearchByAuthor(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_last_name(self):
+        results = self.idx.search_by_author("Lovecraft")
+        self.assertTrue(any("Lovecraft" in b.title or
+                            any(a.last_name == "Lovecraft" for a in b.authors)
+                            for b in results))
+
+    def test_full_name(self):
+        results = self.idx.search_by_author("Arthur Conan Doyle")
+        self.assertTrue(any(b.title == "The Hound of the Baskervilles"
+                            for b in results))
+
+    def test_no_cross_contamination(self):
+        # search_by_author scores on author only — should not match on title
+        results = self.idx.search_by_author("Cthulhu", min_score=0.8)
+        # "Cthulhu" is in the title, not any author — should not score well
+        self.assertFalse(any("Cthulhu" in b.title and
+                             not any("Cthulhu" in a.last_name for a in b.authors)
+                             for b in results))
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — search_by_tag
+# ---------------------------------------------------------------------------
+
+class TestSearchByTag(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_exact_tag(self):
+        results = self.idx.search_by_tag("Horror")
+        titles = {b.title for b in results}
+        self.assertIn("The Call of Cthulhu", titles)
+        self.assertIn("The Shining", titles)
+
+    def test_partial_tag(self):
+        results = self.idx.search_by_tag("Myste")
+        self.assertTrue(any(b.title == "The Hound of the Baskervilles"
+                            for b in results))
+
+    def test_no_match(self):
+        results = self.idx.search_by_tag("Zombies", min_score=0.9)
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — search_by_narrator
+# ---------------------------------------------------------------------------
+
+class TestSearchByNarrator(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_finds_narrator(self):
+        results = self.idx.search_by_narrator("Wayne June")
+        self.assertTrue(any(b.title == "The Call of Cthulhu" for b in results))
+
+    def test_last_name_only(self):
+        results = self.idx.search_by_narrator("June")
+        self.assertTrue(any(b.title == "The Call of Cthulhu" for b in results))
+
+    def test_no_narrator_books_excluded(self):
+        # Books without a narrator should never appear regardless of min_score
+        results = self.idx.search_by_narrator("Wayne", min_score=0.0)
+        for b in results:
+            self.assertIsNotNone(b.narrator)
+
+
+# ---------------------------------------------------------------------------
+# BookIndex — general search
+# ---------------------------------------------------------------------------
+
+class TestSearch(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_scores_all_fields(self):
+        # "Lovecraft" matches via author and title — high enough for general search
+        results = self.idx.search("Lovecraft")
+        self.assertTrue(len(results) > 0)
+
+    def test_returns_sorted(self):
+        results = self.idx.search("Lovecraft")
+        scores = [b.score for b in results]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_min_score_default(self):
+        for b in self.idx.search("anything"):
+            self.assertGreaterEqual(b.score, 0.45)
+
+
+# ---------------------------------------------------------------------------
+# IndexedSource
+# ---------------------------------------------------------------------------
+
+class TestIndexedSource(unittest.TestCase):
+
+    def setUp(self):
+        self.idx = _make_index()
+        self.src = self.idx.as_source()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_iterate_all(self):
+        books = list(self.src.iterate_all())
+        self.assertEqual(len(books), len(ALL_BOOKS))
+
+    def test_search_by_title(self):
+        results = list(self.src.search_by_title("Shining"))
+        self.assertTrue(any(b.title == "The Shining" for b in results))
+
+    def test_search_by_author(self):
+        results = list(self.src.search_by_author("Dickens"))
+        self.assertTrue(any(b.title == "A Tale of Two Cities" for b in results))
+
+    def test_search_by_tag(self):
+        results = list(self.src.search_by_tag("Fantasy"))
+        self.assertTrue(any(b.title == "The Fellowship of the Ring"
+                            for b in results))
+
+    def test_search_by_narrator(self):
+        results = list(self.src.search_by_narrator("Campbell Scott"))
+        self.assertTrue(any(b.title == "The Shining" for b in results))
+
+    def test_source_filter(self):
+        filtered = IndexedSource(self.idx, source_filter="StephenKingAudioBooks")
+        books = list(filtered.iterate_all())
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0].title, "The Shining")
+
+    def test_language_filter(self):
+        de_src = IndexedSource(self.idx, language_filter="de")
+        books = list(de_src.iterate_all())
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0].title, "Faust")
+
+    def test_iterate_by_author(self):
+        results = list(self.src.iterate_by_author("Doyle"))
+        self.assertTrue(any(b.title == "The Hound of the Baskervilles"
+                            for b in results))
+
+    def test_iterate_by_tag(self):
+        results = list(self.src.iterate_by_tag("Mystery"))
+        self.assertTrue(any(b.title == "The Hound of the Baskervilles"
+                            for b in results))
+
+    def test_repr(self):
+        self.assertIn("IndexedSource", repr(self.src))
+        self.assertIn("BookIndex", repr(self.src))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `BookIndex` — a SQLite-backed persistent index for AudioBook catalogues; builds once, searches offline instantly (~15ms via FTS5 vs 10–30s live network)
- Two-phase search: FTS5 pre-filter (C, inverted index) → rapidfuzz WRatio re-rank; automatic fallback to full scan when FTS returns <5 hits so typos never produce zero results
- `IndexedSource` wraps `BookIndex` as a drop-in `AudioBookSource` usable in `search(sources=[...])`
- Follow/unfollow YouTube channels and playlists: `idx.follow(url)` persists them in the DB; `idx.update()` includes them automatically — third-party index consumers get the same sources
- `title_blacklist` parameter filters videos by title substring (case-insensitive); `TheCybrarian` ships with `["update"]` to skip channel-update posts
- CLI: `build`, `update`, `stats`, `search`, `follow`, `unfollow`, `list` subcommands

## Test plan

- [ ] `uv run pytest test/test_index.py` — 57 tests, all passing
- [ ] `python -m audiobooker.index build --sources audioanarchy` completes and reports book count
- [ ] `python -m audiobooker.index search "anarchy"` returns results
- [ ] `python -m audiobooker.index follow <url> --blacklist update` then `list` shows entry
- [ ] `python -m audiobooker.index update` includes followed sources without naming them
- [ ] `python examples/index_usage.py` runs end-to-end

## AI Usage Disclaimer

claude-sonnet-4-6. Human reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)