### PR TITLE
feat: click CLI, local cache with offline playback, duration filters, TheDustyTome

### DIFF
--- a/audiobooker/__init__.py
+++ b/audiobooker/__init__.py
@@ -12,6 +12,6 @@ from audiobooker.utils import check_url_availability, score_book, iter_sitemap_u
 from audiobooker.index import BookIndex, IndexedSource
 
 try:
-    from audiobooker.scrappers.youtube import YoutubeChannelSource, YoutubePlaylistSource, TheCybrarian, HorrorBabble
+    from audiobooker.scrappers.youtube import YoutubeChannelSource, YoutubePlaylistSource, TheCybrarian, HorrorBabble, TheDustyTome
 except ImportError:
     pass

--- a/audiobooker/base.py
+++ b/audiobooker/base.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import List, Optional
 from dataclasses import dataclass, field
 
@@ -77,15 +78,25 @@ class AudioBook:
             self.language = normalize_language(self.language)
 
     def __hash__(self):
-        author_key = tuple(sorted(
-            (a.first_name.lower(), a.last_name.lower()) for a in self.authors
-        ))
-        return hash((self.title.lower().strip(), author_key))
+        return int(self.stable_id(), 16) & 0x7FFFFFFFFFFFFFFF
 
     def __eq__(self, other):
         if not isinstance(other, AudioBook):
             return False
-        return hash(self) == hash(other)
+        return self.stable_id() == other.stable_id()
+
+    def stable_id(self) -> str:
+        """Deterministic hex digest derived from title + authors.
+
+        Safe to use as a cache directory name or database key — unlike
+        Python's built-in hash(), this value is stable across processes
+        and Python versions (not affected by PYTHONHASHSEED).
+        """
+        author_key = "|".join(sorted(
+            f"{a.first_name.lower()}_{a.last_name.lower()}" for a in self.authors
+        ))
+        raw = f"{self.title.lower().strip()}||{author_key}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
     def has_live_streams(self) -> bool:
         """Return True if at least one stream URL is reachable."""

--- a/audiobooker/cache.py
+++ b/audiobooker/cache.py
@@ -1,0 +1,418 @@
+"""Local file cache and download utilities for AudioBook streams.
+
+Cache layout
+------------
+~/.cache/audiobooker/<book_hash>/
+    meta.json          — serialised book metadata
+    <filename>.mp3     — downloaded audio (one file per stream)
+
+Usage
+-----
+    from audiobooker.cache import download, play, is_cached, cached_paths
+
+    book = next(iter(Librivox().search_by_title("Dracula")))
+
+    download(book)               # fetch all streams → cache
+    download(book, stream=0)     # first stream only
+
+    play(book)                   # download if needed, then open with system player
+    play(book, stream=0)
+
+    if is_cached(book):
+        paths = cached_paths(book)
+
+CLI
+---
+    python -m audiobooker.cache download "Dracula" --source librivox
+    python -m audiobooker.cache play "Dracula"
+    python -m audiobooker.cache info "Dracula"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import List, Optional
+
+import requests
+
+from audiobooker.base import AudioBook, AudiobookNarrator, BookAuthor
+from audiobooker.index import BookIndex
+from audiobooker.scrappers.librivox import Librivox
+
+_DEFAULT_CACHE = Path("~/.cache/audiobooker").expanduser()
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+def _book_dir(book, cache_root: Path) -> Path:
+    return cache_root / str(hash(book))
+
+
+def _stream_filename(url: str, index: int) -> str:
+    parsed = urllib.parse.urlparse(url)
+    name = Path(parsed.path).name
+    if not name or "." not in name:
+        name = f"stream_{index}.mp3"
+    return name
+
+
+def _meta_path(book_dir: Path) -> Path:
+    return book_dir / "meta.json"
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+def _book_to_meta(book) -> dict:
+    return {
+        "title":       book.title,
+        "description": book.description,
+        "image":       book.image,
+        "language":    book.language,
+        "year":        book.year,
+        "runtime":     book.runtime,
+        "source":      book.source,
+        "streams":     book.streams,
+        "tags":        book.tags,
+        "authors":     [{"first_name": a.first_name, "last_name": a.last_name}
+                        for a in book.authors],
+        "narrator":    ({"first_name": book.narrator.first_name,
+                         "last_name":  book.narrator.last_name}
+                        if book.narrator else None),
+    }
+
+
+def _meta_to_book(meta: dict):
+    narrator = None
+    if meta.get("narrator"):
+        narrator = AudiobookNarrator(**meta["narrator"])
+    return AudioBook(
+        title=meta["title"],
+        description=meta.get("description", ""),
+        image=meta.get("image", ""),
+        language=meta.get("language", ""),
+        year=meta.get("year", 0),
+        runtime=meta.get("runtime", 0),
+        source=meta.get("source", ""),
+        streams=meta.get("streams", []),
+        tags=meta.get("tags", []),
+        authors=[BookAuthor(**a) for a in meta.get("authors", [])],
+        narrator=narrator,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def is_cached(book, cache_root: Optional[Path] = None) -> bool:
+    """Return True if at least one stream file exists in the cache."""
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    book_dir = _book_dir(book, root)
+    if not book_dir.exists():
+        return False
+    return any(
+        (book_dir / _stream_filename(url, i)).exists()
+        for i, url in enumerate(book.streams)
+    )
+
+
+def cached_paths(book, cache_root: Optional[Path] = None) -> List[Path]:
+    """Return paths to all cached stream files (only those that exist)."""
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    book_dir = _book_dir(book, root)
+    return [
+        p for p in (
+            book_dir / _stream_filename(url, i)
+            for i, url in enumerate(book.streams)
+        )
+        if p.exists()
+    ]
+
+
+def download(book, stream: Optional[int] = None,
+             cache_root: Optional[Path] = None,
+             progress: bool = True) -> List[Path]:
+    """Download stream(s) to cache and return local file paths.
+
+    Parameters
+    ----------
+    book:
+        AudioBook to download.
+    stream:
+        Index into ``book.streams``. When ``None`` all streams are downloaded.
+    cache_root:
+        Override the default ``~/.cache/audiobooker`` directory.
+    progress:
+        Print download progress to stdout.
+
+    Returns
+    -------
+    List of paths to the downloaded files.
+    """
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    book_dir = _book_dir(book, root)
+    book_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write metadata so the cache dir is self-describing
+    meta_file = _meta_path(book_dir)
+    if not meta_file.exists():
+        meta_file.write_text(json.dumps(_book_to_meta(book), indent=2,
+                                        ensure_ascii=False))
+
+    urls = book.streams if stream is None else [book.streams[stream]]
+    base_index = 0 if stream is None else stream
+
+    downloaded = []
+    for i, url in enumerate(urls):
+        idx = base_index + i
+        dest = book_dir / _stream_filename(url, idx)
+        if dest.exists():
+            if progress:
+                print(f"  [cache] {dest.name}")
+            downloaded.append(dest)
+            continue
+
+        if progress:
+            print(f"  [download] {url}")
+
+        try:
+            resp = requests.get(url, stream=True, timeout=30)
+            resp.raise_for_status()
+            total = int(resp.headers.get("content-length", 0))
+            tmp = dest.with_suffix(".part")
+            written = 0
+            with tmp.open("wb") as f:
+                for chunk in resp.iter_content(chunk_size=65536):
+                    f.write(chunk)
+                    written += len(chunk)
+                    if progress and total:
+                        pct = written * 100 // total
+                        print(f"\r    {pct:3d}%  {written // 1024}KB / {total // 1024}KB",
+                              end="", flush=True)
+            if progress and total:
+                print()
+            tmp.rename(dest)
+            downloaded.append(dest)
+        except Exception as exc:
+            if progress:
+                print(f"  [error] {exc}")
+            tmp = dest.with_suffix(".part")
+            if tmp.exists():
+                tmp.unlink()
+
+    return downloaded
+
+
+def play(book, stream: int = 0,
+         cache_root: Optional[Path] = None,
+         progress: bool = True) -> None:
+    """Play a book stream, downloading to cache first if needed.
+
+    Uses the system's default audio player (``xdg-open`` on Linux,
+    ``open`` on macOS, ``start`` on Windows).
+
+    Parameters
+    ----------
+    book:
+        AudioBook to play.
+    stream:
+        Index of the stream to play (default 0).
+    cache_root:
+        Override cache directory.
+    progress:
+        Show download progress.
+    """
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    book_dir = _book_dir(book, root)
+    dest = book_dir / _stream_filename(book.streams[stream], stream)
+
+    if not dest.exists():
+        paths = download(book, stream=stream, cache_root=root, progress=progress)
+        if not paths:
+            raise RuntimeError(f"Download failed for {book.title!r}")
+        dest = paths[0]
+
+    _open_file(dest)
+
+
+def clear_cache(book=None, cache_root: Optional[Path] = None) -> int:
+    """Remove cached files.
+
+    Parameters
+    ----------
+    book:
+        Remove only this book's cache. When ``None``, clears the entire cache.
+
+    Returns
+    -------
+    Number of directories removed.
+    """
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    if book is not None:
+        d = _book_dir(book, root)
+        if d.exists():
+            shutil.rmtree(d)
+            return 1
+        return 0
+    if root.exists():
+        count = sum(1 for _ in root.iterdir())
+        shutil.rmtree(root)
+        return count
+    return 0
+
+
+def list_cached(cache_root: Optional[Path] = None):
+    """Yield AudioBook objects for every book in the cache."""
+    root = Path(cache_root) if cache_root else _DEFAULT_CACHE
+    if not root.exists():
+        return
+    for book_dir in sorted(root.iterdir()):
+        meta_file = _meta_path(book_dir)
+        if meta_file.exists():
+            try:
+                meta = json.loads(meta_file.read_text())
+                yield _meta_to_book(meta)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _open_file(path: Path) -> None:
+    if sys.platform == "darwin":
+        subprocess.Popen(["open", str(path)])
+    elif sys.platform == "win32":
+        os.startfile(str(path))
+    else:
+        subprocess.Popen(["xdg-open", str(path)])
+
+
+# ---------------------------------------------------------------------------
+# CLI  (python -m audiobooker.cache)
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="python -m audiobooker.cache",
+        description="Download and play audiobooks with local caching.",
+    )
+    parser.add_argument("--cache", default=None, help="Cache directory")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_dl = sub.add_parser("download", help="Download book streams to cache")
+    p_dl.add_argument("query")
+    p_dl.add_argument("--source", default=None,
+                      help="Limit search to this source name")
+    p_dl.add_argument("--stream", type=int, default=None,
+                      help="Stream index (default: all)")
+    p_dl.add_argument("--method", default="search_by_title",
+                      choices=["search_by_title", "search_by_author",
+                               "search", "search_by_tag"])
+
+    p_play = sub.add_parser("play", help="Play a book (download if not cached)")
+    p_play.add_argument("query")
+    p_play.add_argument("--source", default=None)
+    p_play.add_argument("--stream", type=int, default=0)
+    p_play.add_argument("--method", default="search_by_title",
+                        choices=["search_by_title", "search_by_author",
+                                 "search", "search_by_tag"])
+
+    p_info = sub.add_parser("info", help="Show cache info for a book")
+    p_info.add_argument("query")
+    p_info.add_argument("--source", default=None)
+    p_info.add_argument("--method", default="search_by_title",
+                        choices=["search_by_title", "search_by_author",
+                                 "search", "search_by_tag"])
+
+    sub.add_parser("list", help="List all cached books")
+    sub.add_parser("clear", help="Clear the entire cache")
+
+    args = parser.parse_args()
+    cache_root = Path(args.cache) if args.cache else None
+
+    if args.cmd == "list":
+        books = list(list_cached(cache_root))
+        if not books:
+            print("Cache is empty.")
+        for b in books:
+            paths = cached_paths(b, cache_root)
+            size = sum(p.stat().st_size for p in paths if p.exists())
+            print(f"  {b.title!r}  [{b.source}]  {size // 1024}KB  {len(paths)} file(s)")
+        return
+
+    if args.cmd == "clear":
+        n = clear_cache(cache_root=cache_root)
+        print(f"Cleared {n} cached book(s).")
+        return
+
+    # Commands that need a book lookup
+    book = _find_book(args.query, args.method, getattr(args, "source", None))
+    if book is None:
+        print(f"No results for {args.query!r}")
+        sys.exit(1)
+
+    if args.cmd == "download":
+        paths = download(book, stream=args.stream, cache_root=cache_root)
+        print(f"\nDownloaded {len(paths)} file(s):")
+        for p in paths:
+            print(f"  {p}")
+
+    elif args.cmd == "play":
+        play(book, stream=args.stream, cache_root=cache_root)
+        print(f"Playing: {book.title!r}")
+
+    elif args.cmd == "info":
+        paths = cached_paths(book, cache_root)
+        print(f"Title:   {book.title}")
+        print(f"Source:  {book.source}")
+        print(f"Cached:  {is_cached(book, cache_root)}")
+        print(f"Streams: {len(book.streams)}")
+        for i, (url, p) in enumerate(zip(book.streams,
+                                         [book.streams[j] for j in range(len(book.streams))])):
+            local = cache_root / str(hash(book)) / _stream_filename(url, i) if cache_root \
+                else _DEFAULT_CACHE / str(hash(book)) / _stream_filename(url, i)
+            status = f"{local.stat().st_size // 1024}KB" if local.exists() else "not cached"
+            print(f"  [{i}] {url}  →  {status}")
+    else:
+        parser.print_help()
+
+
+def _find_book(query: str, method: str, source_filter: Optional[str] = None):
+    """Search the local index first, fall back to live Librivox search."""
+    try:
+        idx = BookIndex()
+        fn = getattr(idx, method)
+        kw = {"max_results": 1}
+        if source_filter:
+            kw["source"] = source_filter
+        results = fn(query, **kw)
+        idx.close()
+        if results:
+            return results[0]
+    except Exception:
+        pass
+
+    src = Librivox()
+    fn = getattr(src, method, src.search_by_title)
+    for book in fn(query):
+        if source_filter and book.source != source_filter:
+            continue
+        return book
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/audiobooker/cache.py
+++ b/audiobooker/cache.py
@@ -54,15 +54,15 @@ _DEFAULT_CACHE = Path("~/.cache/audiobooker").expanduser()
 # ---------------------------------------------------------------------------
 
 def _book_dir(book, cache_root: Path) -> Path:
-    return cache_root / str(hash(book))
+    return cache_root / book.stable_id()
 
 
 def _stream_filename(url: str, index: int) -> str:
     parsed = urllib.parse.urlparse(url)
     name = Path(parsed.path).name
     if not name or "." not in name:
-        name = f"stream_{index}.mp3"
-    return name
+        name = "stream.mp3"
+    return f"{index:02d}_{name}"
 
 
 def _meta_path(book_dir: Path) -> Path:
@@ -380,10 +380,10 @@ def main():
         print(f"Source:  {book.source}")
         print(f"Cached:  {is_cached(book, cache_root)}")
         print(f"Streams: {len(book.streams)}")
-        for i, (url, p) in enumerate(zip(book.streams,
-                                         [book.streams[j] for j in range(len(book.streams))])):
-            local = cache_root / str(hash(book)) / _stream_filename(url, i) if cache_root \
-                else _DEFAULT_CACHE / str(hash(book)) / _stream_filename(url, i)
+        root = cache_root or _DEFAULT_CACHE
+        book_dir = _book_dir(book, root)
+        for i, url in enumerate(book.streams):
+            local = book_dir / _stream_filename(url, i)
             status = f"{local.stat().st_size // 1024}KB" if local.exists() else "not cached"
             print(f"  [{i}] {url}  →  {status}")
     else:

--- a/audiobooker/cli.py
+++ b/audiobooker/cli.py
@@ -1,0 +1,464 @@
+"""Click-based CLI for audiobooker.
+
+Entry point: audiobooker (registered in pyproject.toml)
+
+Commands
+--------
+  audiobooker search   <query>    — live search across web sources
+  audiobooker index               — manage the local SQLite index
+    index build
+    index update
+    index search  <query>
+    index stats
+    index follow  <url>
+    index unfollow <url>
+    index list
+  audiobooker cache               — local file cache
+    cache download <query>
+    cache play     <query>
+    cache list
+    cache clear
+    cache info     <query>
+"""
+
+import sys
+
+import click
+
+from audiobooker.cache import (
+    clear_cache, download, is_cached, list_cached, cached_paths, play,
+)
+from audiobooker.index import BookIndex, _resolve_sources, _default_sources
+
+
+# ---------------------------------------------------------------------------
+# Shared options
+# ---------------------------------------------------------------------------
+
+_db_option = click.option(
+    "--db", default=None, metavar="PATH",
+    help="Index database path (default ~/.audiobooker/index.db)",
+)
+_cache_option = click.option(
+    "--cache-dir", default=None, metavar="PATH",
+    help="Cache directory (default ~/.cache/audiobooker)",
+)
+_source_option = click.option(
+    "--source", default=None, metavar="NAME",
+    help="Limit to books from this source",
+)
+_language_option = click.option(
+    "--language", default=None, metavar="CODE",
+    help="Limit to books with this language code (e.g. en, de)",
+)
+_n_option = click.option(
+    "-n", default=10, show_default=True,
+    help="Maximum number of results",
+)
+_min_score_option = click.option(
+    "--min-score", default=0.45, show_default=True, metavar="FLOAT",
+    help="Minimum fuzzy match score (0–1)",
+)
+_min_dur_option = click.option(
+    "--min-duration", default=0, metavar="SECS",
+    help="Minimum runtime in seconds",
+)
+_max_dur_option = click.option(
+    "--max-duration", default=0, metavar="SECS",
+    help="Maximum runtime in seconds",
+)
+_method_option = click.option(
+    "--method",
+    type=click.Choice(["search", "search_by_title", "search_by_author",
+                       "search_by_tag", "search_by_narrator"]),
+    default="search_by_title", show_default=True,
+    help="Search method",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _print_book(book, verbose: bool = False):
+    authors = ", ".join(
+        f"{a.first_name} {a.last_name}".strip() for a in book.authors
+    ) or "?"
+    score = f"[{book.score:.2f}] " if book.score else ""
+    runtime = f"  {book.runtime // 60}min" if book.runtime else ""
+    click.echo(f"  {score}{book.title!r}  — {authors}{runtime}  [{book.source}]")
+    if verbose:
+        if book.tags:
+            click.echo(f"      tags: {', '.join(book.tags)}")
+        if book.narrator:
+            n = f"{book.narrator.first_name} {book.narrator.last_name}".strip()
+            click.echo(f"      narrator: {n}")
+        if book.streams:
+            click.echo(f"      streams: {len(book.streams)}")
+            for s in book.streams[:2]:
+                click.echo(f"        {s}")
+
+
+def _open_index(db):
+    return BookIndex(db)
+
+
+def _find_book(query, method, db, source):
+    """Look up a book: index first, live Librivox fallback."""
+    from audiobooker.scrappers.librivox import Librivox
+    try:
+        idx = _open_index(db)
+        fn = getattr(idx, method)
+        kw = {"max_results": 1}
+        if source:
+            kw["source"] = source
+        results = fn(query, **kw)
+        idx.close()
+        if results:
+            return results[0]
+    except Exception:
+        pass
+    src = Librivox()
+    fn = getattr(src, method, src.search_by_title)
+    for book in fn(query):
+        if source and book.source != source:
+            continue
+        return book
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Root group
+# ---------------------------------------------------------------------------
+
+@click.group()
+@click.version_option(package_name="audiobooker")
+def cli():
+    """audiobooker — search, index, and cache audiobooks from the web."""
+
+
+# ---------------------------------------------------------------------------
+# audiobooker search
+# ---------------------------------------------------------------------------
+
+@cli.command("search")
+@click.argument("query")
+@_method_option
+@_n_option
+@_min_score_option
+@_source_option
+@_language_option
+@_min_dur_option
+@_max_dur_option
+@click.option("--timeout", default=30, show_default=True, metavar="SECS")
+@click.option("-v", "--verbose", is_flag=True)
+def cmd_search(query, method, n, min_score, source, language,
+               min_duration, max_duration, timeout, verbose):
+    """Live search across all web sources."""
+    from audiobooker import search as live_search
+    from audiobooker.scrappers.librivox import Librivox
+    from audiobooker.scrappers.loyalbooks import LoyalBooks
+    from audiobooker.scrappers.goldenaudiobooks import GoldenAudioBooks
+    from audiobooker.scrappers.audioanarchy import AudioAnarchy
+    from audiobooker.scrappers.darkerprojects import DarkerProjects
+
+    sources = [Librivox(), LoyalBooks(), AudioAnarchy(), DarkerProjects(), GoldenAudioBooks()]
+    count = 0
+    for book in live_search(query, sources=sources, timeout=timeout,
+                            max_per_source=n):
+        if source and book.source != source:
+            continue
+        if language and book.language != language:
+            continue
+        if min_duration and book.runtime < min_duration:
+            continue
+        if max_duration and book.runtime > max_duration:
+            continue
+        _print_book(book, verbose)
+        count += 1
+        if count >= n:
+            break
+    if not count:
+        click.echo("No results.")
+
+
+# ---------------------------------------------------------------------------
+# audiobooker index  (sub-group)
+# ---------------------------------------------------------------------------
+
+@cli.group("index")
+@_db_option
+@click.pass_context
+def cmd_index(ctx, db):
+    """Manage the local SQLite book index."""
+    ctx.ensure_object(dict)
+    ctx.obj["db"] = db
+
+
+@cmd_index.command("build")
+@click.option("--sources", "-s", multiple=True, metavar="NAME",
+              help="Source names (default: all web sources)")
+@click.pass_context
+def index_build(ctx, sources):
+    """Clear and rebuild the index for the given sources."""
+    db = ctx.obj["db"]
+    src_list = _resolve_sources(sources) if sources else None
+    idx = _open_index(db)
+    click.echo("Building index…")
+    total = idx.build(sources=src_list)
+    idx.close()
+    click.echo(f"Done. {total} books indexed.")
+
+
+@cmd_index.command("update")
+@click.option("--sources", "-s", multiple=True, metavar="NAME",
+              help="Source names (default: all + followed YouTube sources)")
+@click.pass_context
+def index_update(ctx, sources):
+    """Add new books without clearing existing records."""
+    db = ctx.obj["db"]
+    src_list = _resolve_sources(sources) if sources else None
+    idx = _open_index(db)
+    click.echo("Updating index…")
+    total = idx.update(sources=src_list)
+    idx.close()
+    click.echo(f"Done. {total} new books added.")
+
+
+@cmd_index.command("stats")
+@click.pass_context
+def index_stats(ctx):
+    """Show index statistics."""
+    db = ctx.obj["db"]
+    idx = _open_index(db)
+    s = idx.stats()
+    idx.close()
+    click.echo(f"Total books: {s['total']}\n")
+    click.echo("By source:")
+    for src, n in s["by_source"].items():
+        click.echo(f"  {src:30s} {n}")
+    click.echo("\nBy language:")
+    for lang, n in s["by_language"].items():
+        click.echo(f"  {lang or '(unknown)':10s} {n}")
+
+
+@cmd_index.command("search")
+@click.argument("query")
+@_method_option
+@_n_option
+@_min_score_option
+@_source_option
+@_language_option
+@_min_dur_option
+@_max_dur_option
+@click.option("-v", "--verbose", is_flag=True)
+@click.pass_context
+def index_search(ctx, query, method, n, min_score, source, language,
+                 min_duration, max_duration, verbose):
+    """Search the local index."""
+    db = ctx.obj["db"]
+    idx = _open_index(db)
+    fn = getattr(idx, method)
+    kw = dict(max_results=n, min_score=min_score)
+    if source:
+        kw["source"] = source
+    if language:
+        kw["language"] = language
+    if min_duration:
+        kw["min_duration"] = min_duration
+    if max_duration:
+        kw["max_duration"] = max_duration
+    results = fn(query, **kw)
+    idx.close()
+    click.echo(f"{len(results)} result(s) for {query!r}:\n")
+    for book in results:
+        _print_book(book, verbose)
+    if not results:
+        click.echo("No results.")
+
+
+@cmd_index.command("follow")
+@click.argument("url")
+@click.option("--kind", type=click.Choice(["channel", "playlist"]),
+              default="channel", show_default=True)
+@click.option("--name", default="", help="Human-readable label")
+@click.option("--tags", multiple=True, metavar="TAG")
+@click.option("--language", default="en", show_default=True)
+@click.option("--min-runtime", default=300, show_default=True, metavar="SECS",
+              help="Skip videos shorter than N seconds")
+@click.option("--blacklist", multiple=True, metavar="PHRASE",
+              help="Skip books whose title contains this string (repeatable)")
+@click.pass_context
+def index_follow(ctx, url, kind, name, tags, language, min_runtime, blacklist):
+    """Follow a YouTube channel or playlist."""
+    db = ctx.obj["db"]
+    idx = _open_index(db)
+    idx.follow(url, kind=kind, name=name, tags=list(tags),
+               language=language, min_runtime=min_runtime,
+               title_blacklist=list(blacklist))
+    idx.close()
+    label = name or url
+    click.echo(f"Following {kind}: {label}")
+
+
+@cmd_index.command("unfollow")
+@click.argument("url")
+@click.pass_context
+def index_unfollow(ctx, url):
+    """Stop following a YouTube channel or playlist."""
+    db = ctx.obj["db"]
+    idx = _open_index(db)
+    removed = idx.unfollow(url)
+    idx.close()
+    if removed:
+        click.echo(f"Unfollowed: {url}")
+    else:
+        click.secho(f"Not found: {url}", fg="yellow")
+
+
+@cmd_index.command("list")
+@click.pass_context
+def index_list(ctx):
+    """List all followed YouTube sources."""
+    db = ctx.obj["db"]
+    idx = _open_index(db)
+    followed = idx.list_followed()
+    idx.close()
+    if not followed:
+        click.echo("No followed sources.")
+        return
+    click.echo(f"{'Kind':<10} {'Name/URL':<50} {'Lang':<6} {'Tags'}")
+    click.echo("-" * 80)
+    for f in followed:
+        label = f["name"] or f["url"]
+        tags = ", ".join(f["tags"]) if f["tags"] else ""
+        bl = f"  blacklist={f['title_blacklist']}" if f["title_blacklist"] else ""
+        click.echo(f"  {f['kind']:<8} {label:<50} {f['language']:<6} {tags}{bl}")
+
+
+# ---------------------------------------------------------------------------
+# audiobooker cache  (sub-group)
+# ---------------------------------------------------------------------------
+
+@cli.group("cache")
+@_cache_option
+@click.pass_context
+def cmd_cache(ctx, cache_dir):
+    """Download and manage cached audiobook files."""
+    ctx.ensure_object(dict)
+    from pathlib import Path
+    ctx.obj["cache_root"] = Path(cache_dir) if cache_dir else None
+
+
+@cmd_cache.command("download")
+@click.argument("query")
+@_method_option
+@_source_option
+@_db_option
+@click.option("--stream", default=None, type=int, metavar="INDEX",
+              help="Stream index (default: all)")
+@click.pass_context
+def cache_download(ctx, query, method, source, db, stream):
+    """Download a book's streams to cache."""
+    cache_root = ctx.obj["cache_root"]
+    book = _find_book(query, method, db, source)
+    if not book:
+        click.secho(f"No results for {query!r}", fg="red")
+        sys.exit(1)
+    click.echo(f"Downloading: {book.title!r}")
+    paths = download(book, stream=stream, cache_root=cache_root)
+    if paths:
+        click.echo(f"\nDownloaded {len(paths)} file(s):")
+        for p in paths:
+            click.echo(f"  {p}")
+    else:
+        click.secho("Download failed.", fg="red")
+        sys.exit(1)
+
+
+@cmd_cache.command("play")
+@click.argument("query")
+@_method_option
+@_source_option
+@_db_option
+@click.option("--stream", default=0, show_default=True, type=int)
+@click.pass_context
+def cache_play(ctx, query, method, source, db, stream):
+    """Play a book (downloads to cache first if needed)."""
+    cache_root = ctx.obj["cache_root"]
+    book = _find_book(query, method, db, source)
+    if not book:
+        click.secho(f"No results for {query!r}", fg="red")
+        sys.exit(1)
+    click.echo(f"Playing: {book.title!r}")
+    play(book, stream=stream, cache_root=cache_root)
+
+
+@cmd_cache.command("list")
+@click.pass_context
+def cache_list(ctx):
+    """List all cached books."""
+    cache_root = ctx.obj["cache_root"]
+    books = list(list_cached(cache_root))
+    if not books:
+        click.echo("Cache is empty.")
+        return
+    total_kb = 0
+    for book in books:
+        paths = cached_paths(book, cache_root)
+        size_kb = sum(p.stat().st_size for p in paths if p.exists()) // 1024
+        total_kb += size_kb
+        click.echo(f"  {book.title!r}  [{book.source}]  {size_kb}KB  {len(paths)} file(s)")
+    click.echo(f"\nTotal: {len(books)} book(s), {total_kb}KB")
+
+
+@cmd_cache.command("clear")
+@click.argument("query", required=False)
+@_method_option
+@_source_option
+@_db_option
+@click.confirmation_option(prompt="Clear cache?")
+@click.pass_context
+def cache_clear(ctx, query, method, source, db):
+    """Clear cache for one book or the entire cache."""
+    cache_root = ctx.obj["cache_root"]
+    if query:
+        book = _find_book(query, method, db, source)
+        if not book:
+            click.secho(f"No results for {query!r}", fg="red")
+            sys.exit(1)
+        n = clear_cache(book, cache_root)
+        click.echo(f"Cleared {n} cached book(s).")
+    else:
+        n = clear_cache(cache_root=cache_root)
+        click.echo(f"Cleared {n} cached book(s).")
+
+
+@cmd_cache.command("info")
+@click.argument("query")
+@_method_option
+@_source_option
+@_db_option
+@click.pass_context
+def cache_info(ctx, query, method, source, db):
+    """Show cache status for a book."""
+    cache_root = ctx.obj["cache_root"]
+    book = _find_book(query, method, db, source)
+    if not book:
+        click.secho(f"No results for {query!r}", fg="red")
+        sys.exit(1)
+    click.echo(f"Title:   {book.title}")
+    click.echo(f"Source:  {book.source}")
+    click.echo(f"Cached:  {is_cached(book, cache_root)}")
+    click.echo(f"Streams: {len(book.streams)}")
+    from audiobooker.cache import _book_dir, _stream_filename, _DEFAULT_CACHE
+    root = cache_root or _DEFAULT_CACHE
+    for i, url in enumerate(book.streams):
+        local = _book_dir(book, root) / _stream_filename(url, i)
+        status = f"{local.stat().st_size // 1024}KB" if local.exists() else "not cached"
+        click.echo(f"  [{i}] {url}")
+        click.echo(f"       → {local}  ({status})")
+
+
+if __name__ == "__main__":
+    cli()

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS followed_sources (
 
 CREATE TABLE IF NOT EXISTS books (
     id            INTEGER PRIMARY KEY,
-    hash          INTEGER UNIQUE NOT NULL,
+    hash          TEXT UNIQUE NOT NULL,
     title         TEXT NOT NULL,
     description   TEXT DEFAULT '',
     image         TEXT DEFAULT '',
@@ -128,7 +128,7 @@ def _book_to_row(book: AudioBook) -> dict:
         narrator_json = json.dumps({"first_name": book.narrator.first_name,
                                     "last_name":  book.narrator.last_name})
     return {
-        "hash":          hash(book),
+        "hash":          book.stable_id(),
         "title":         book.title,
         "description":   book.description,
         "image":         book.image,
@@ -212,27 +212,7 @@ class BookIndex:
         self._con.commit()
 
     def _migrate(self):
-        """Evolve schema to current version without destroying data."""
-        # v1→v2: books table got an auto-increment id column
-        cols = {r[1] for r in self._con.execute(
-            "PRAGMA table_info(books)"
-        ).fetchall()}
-        if cols and "id" not in cols:
-            self._con.executescript("""
-                DROP TABLE IF EXISTS books_fts;
-                DROP TABLE IF EXISTS books;
-            """)
-            self._con.commit()
-
-        # v2→v3: followed_sources got title_blacklist column
-        fs_cols = {r[1] for r in self._con.execute(
-            "PRAGMA table_info(followed_sources)"
-        ).fetchall()}
-        if fs_cols and "title_blacklist" not in fs_cols:
-            self._con.execute(
-                "ALTER TABLE followed_sources ADD COLUMN title_blacklist TEXT DEFAULT '[]'"
-            )
-            self._con.commit()
+        pass  # no legacy DBs exist; schema is created fresh by _SCHEMA
 
     # ------------------------------------------------------------------
     # Building
@@ -325,7 +305,7 @@ class BookIndex:
 
     def _upsert_if_new(self, book: AudioBook) -> Optional[int]:
         """Insert book if not already present. Returns new rowid or None."""
-        h = hash(book)
+        h = book.stable_id()
         existing = self._con.execute(
             "SELECT id FROM books WHERE hash = ?", (h,)
         ).fetchone()

--- a/audiobooker/index.py
+++ b/audiobooker/index.py
@@ -419,11 +419,15 @@ class BookIndex:
         return [_row_to_book(r) for r in rows]
 
     def _rank(self, query: str, books: List[AudioBook], method: str,
-              min_score: float, max_results: int) -> List[AudioBook]:
+              min_score: float, max_results: int,
+              min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         results = []
         for book in books:
-            # narrator search: skip books that have no narrator at all
             if method == "search_by_narrator" and not book.narrator:
+                continue
+            if min_duration and book.runtime < min_duration:
+                continue
+            if max_duration and book.runtime > max_duration:
                 continue
             book.score = score_book(query, book, method)
             if book.score >= min_score:
@@ -435,6 +439,7 @@ class BookIndex:
                 fts_field: Optional[str],
                 max_results: int, min_score: float,
                 source: Optional[str], language: Optional[str],
+                min_duration: int = 0, max_duration: int = 0,
                 fts_fallback_threshold: int = 5) -> List[AudioBook]:
         """Two-phase search: FTS pre-filter → rapidfuzz re-rank.
 
@@ -443,48 +448,57 @@ class BookIndex:
         """
         candidates = self._fts_search(query, fts_field, source, language)
         if len(candidates) < fts_fallback_threshold:
-            # Broaden: try without field restriction
             if fts_field:
                 candidates = self._fts_search(query, None, source, language)
-            # Still too few — full rapidfuzz scan (typo tolerance)
             if len(candidates) < fts_fallback_threshold:
                 candidates = self._full_scan(source, language)
-        return self._rank(query, candidates, method, min_score, max_results)
+        return self._rank(query, candidates, method, min_score, max_results,
+                          min_duration, max_duration)
 
     def search(self, query: str, max_results: int = 10,
                min_score: float = 0.45,
                source: Optional[str] = None,
-               language: Optional[str] = None) -> List[AudioBook]:
+               language: Optional[str] = None,
+               min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         return self._search(query, "search", None,
-                            max_results, min_score, source, language)
+                            max_results, min_score, source, language,
+                            min_duration, max_duration)
 
     def search_by_title(self, query: str, max_results: int = 10,
                         min_score: float = 0.45,
                         source: Optional[str] = None,
-                        language: Optional[str] = None) -> List[AudioBook]:
+                        language: Optional[str] = None,
+                        min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         return self._search(query, "search_by_title", "title",
-                            max_results, min_score, source, language)
+                            max_results, min_score, source, language,
+                            min_duration, max_duration)
 
     def search_by_author(self, query: str, max_results: int = 10,
                          min_score: float = 0.45,
                          source: Optional[str] = None,
-                         language: Optional[str] = None) -> List[AudioBook]:
+                         language: Optional[str] = None,
+                         min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         return self._search(query, "search_by_author", "authors_text",
-                            max_results, min_score, source, language)
+                            max_results, min_score, source, language,
+                            min_duration, max_duration)
 
     def search_by_tag(self, query: str, max_results: int = 10,
                       min_score: float = 0.45,
                       source: Optional[str] = None,
-                      language: Optional[str] = None) -> List[AudioBook]:
+                      language: Optional[str] = None,
+                      min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         return self._search(query, "search_by_tag", "tags_text",
-                            max_results, min_score, source, language)
+                            max_results, min_score, source, language,
+                            min_duration, max_duration)
 
     def search_by_narrator(self, query: str, max_results: int = 10,
                            min_score: float = 0.45,
                            source: Optional[str] = None,
-                           language: Optional[str] = None) -> List[AudioBook]:
+                           language: Optional[str] = None,
+                           min_duration: int = 0, max_duration: int = 0) -> List[AudioBook]:
         return self._search(query, "search_by_narrator", "narrator_text",
-                            max_results, min_score, source, language)
+                            max_results, min_score, source, language,
+                            min_duration, max_duration)
 
     # ------------------------------------------------------------------
     # Iteration
@@ -787,6 +801,10 @@ def main():
     p_search.add_argument("--n", type=int, default=10)
     p_search.add_argument("--source", default=None)
     p_search.add_argument("--language", default=None)
+    p_search.add_argument("--min-duration", type=int, default=0,
+                          metavar="SECS", help="Minimum runtime in seconds")
+    p_search.add_argument("--max-duration", type=int, default=0,
+                          metavar="SECS", help="Maximum runtime in seconds")
 
     p_follow = sub.add_parser("follow", help="Follow a YouTube channel or playlist")
     p_follow.add_argument("url", help="Channel or playlist URL")
@@ -863,6 +881,10 @@ def main():
             kw["source"] = args.source
         if args.language:
             kw["language"] = args.language
+        if args.min_duration:
+            kw["min_duration"] = args.min_duration
+        if args.max_duration:
+            kw["max_duration"] = args.max_duration
         results = fn(args.query, max_results=args.n, **kw)
         print(f"{len(results)} result(s) for {args.query!r}:\n")
         for book in results:

--- a/audiobooker/scrappers/youtube.py
+++ b/audiobooker/scrappers/youtube.py
@@ -481,3 +481,18 @@ class HorrorBabble(YoutubeChannelSource):
             language="en",
             min_runtime=300,
         )
+
+
+class TheDustyTome(YoutubeChannelSource):
+    """Classic literature and fantasy audiobooks read by The Dusty Tome."""
+
+    def __init__(self):
+        super().__init__(
+            channel_url="https://www.youtube.com/@TheDustyTome/videos",
+            authors=[],  # extracted per-video from title
+            narrator=None,  # extracted per-video
+            tags=["Classic Literature", "Fantasy", "Audiobook"],
+            language="en",
+            min_runtime=300,
+            extract_metadata=True,
+        )

--- a/audiobooker/scrappers/youtube.py
+++ b/audiobooker/scrappers/youtube.py
@@ -171,8 +171,8 @@ _NARRATOR_RE = re.compile(
     r'\b(?:narrated|read)\s+by\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})',
     re.IGNORECASE,
 )
-# Hashtags: #audiobook #horror
-_HASHTAG_RE = re.compile(r'#(\w+)')
+# Hashtags: #audiobook  OR  # audiobook (space after #)
+_HASHTAG_RE = re.compile(r'#\s*(\w+)')
 # Year: "published in 1934", "publication in January 1934", "March 1933"
 _YEAR_RE = re.compile(r'\b(1[6-9]\d{2}|20[0-2]\d)\b')
 # Pipe/dash noise suffixes: "| HorrorBabble", "| Clark Ashton Smith's Zothique Cycle",
@@ -180,7 +180,18 @@ _YEAR_RE = re.compile(r'\b(1[6-9]\d{2}|20[0-2]\d)\b')
 _NOISE_SUFFIX_RE = re.compile(
     r'\s*[|/–\-]\s*(?:HorrorBabble|The Cybrarian'
     r"|[A-Z][a-zA-Z ']+Cycle"
-    r'|(?:A\s+)?(?:Cthulhu Mythos|Doctor Satan|Clean Read).*)',
+    r'|(?:A\s+)?(?:Cthulhu Mythos|Doctor Satan|Clean Read).*'
+    r'|(?:FULL\s+)?AUDIOBOOK.*'
+    r'|(?:AUDIO\s*DRAMA|AUDIODRAMA).*'
+    r'|in\s+INFOVISION.*'
+    r'|INFOVISION.*)',
+    re.IGNORECASE,
+)
+# Trailing standalone noise not preceded by a separator
+_TRAILING_NOISE_RE = re.compile(
+    r'\s*[-–]?\s*(?:FULL\s+AUDIOBOOK|AUDIOBOOK|AUDIO\s*DRAMA|AUDIODRAMA'
+    r'|(?:in|an)\s+INFOVISION(?:\s+Audio\s+Drama)?|INFOVISION'
+    r'|REMASTERED)\s*[!]?\s*$',
     re.IGNORECASE,
 )
 # Bracketed noise: [PREVIEW], [REMASTERED], [English], [unabridged], etc.
@@ -240,6 +251,7 @@ def extract_yt_metadata(title: str, desc: str) -> dict:
     # --- clean title: strip hashtags, noise suffixes, bracketed labels ---
     clean = _BRACKET_RE.sub("", title)
     clean = _NOISE_SUFFIX_RE.sub("", clean)
+    clean = _TRAILING_NOISE_RE.sub("", clean)
     clean = _HASHTAG_RE.sub("", clean).strip(" ,–-|")
     # collapse multiple spaces
     clean = re.sub(r'\s{2,}', ' ', clean).strip()
@@ -461,7 +473,8 @@ class TheCybrarian(YoutubeChannelSource):
             tags=["Fantasy", "Sword and Sorcery", "Robert E. Howard", "Conan"],
             language="en",
             min_runtime=120,
-            title_blacklist=["update"],
+            title_blacklist=["update", "preview", "cracking packs", "magic the gathering",
+                             "board game", "tabletop", "mtg"],
         )
 
 
@@ -482,15 +495,15 @@ class HorrorBabble(YoutubeChannelSource):
 
 
 class TheDustyTome(YoutubeChannelSource):
-    """Classic literature and fantasy audiobooks read by The Dusty Tome."""
+    """Classic literature, horror, and weird fiction audiobooks by The Dusty Tome."""
 
     def __init__(self):
         super().__init__(
             channel_url="https://www.youtube.com/@TheDustyTome/videos",
             authors=[],  # extracted per-video from title
             narrator=None,  # extracted per-video
-            tags=["Classic Literature", "Fantasy", "Audiobook"],
+            tags=["Classic Literature", "Horror", "Weird Fiction", "Audiobook"],
             language="en",
-            min_runtime=300,
+            min_runtime=600,
             extract_metadata=True,
         )

--- a/audiobooker/scrappers/youtube.py
+++ b/audiobooker/scrappers/youtube.py
@@ -279,10 +279,8 @@ def _video_to_book(v: dict, authors: List[BookAuthor], tags: List[str],
         resolved_narrator = narrator if narrator is not None else meta["narrator"]
         # Year
         year = meta["year"]
-        # Merge tags: configured base + hashtag-derived extras (deduplicated)
-        extra_lower = {t.lower() for t in tags}
-        extra_tags = [t for t in meta["extra_tags"] if t not in extra_lower]
-        resolved_tags = tags + extra_tags
+        # Tags: use per-video hashtags when available; fall back to channel base tags
+        resolved_tags = meta["extra_tags"] if meta["extra_tags"] else tags
     else:
         resolved_authors = authors
         resolved_narrator = narrator

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ See also the `examples/` directory for runnable code:
 | Example | Shows |
 |---|---|
 | `index_usage.py` | Build index, offline search, `IndexedSource` in unified search |
+| `cache_usage.py` | Download streams to cache, `play()`, duration filters |
+| `download_cybrarian.py` | Bulk-download TheCybrarian channel; `--dry-run`, `--indexed` flags |
 | `search_all_sources.py` | Unified search across all web sources |
 | `search_librivox.py` | Librivox REST API search |
 | `search_loyalbooks.py` | LoyalBooks genre and title search |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@
 | [scoring.md](scoring.md) | How scores are computed, field weights, fuzzy matching details |
 | [sources.md](sources.md) | Each web scraper — catalogue size, native search, quirks |
 | [youtube.md](youtube.md) | YouTube channel and playlist sources (`YoutubeChannelSource`, `YoutubePlaylistSource`, `TheCybrarian`, `HorrorBabble`) |
-| [index.md](index.md) | `BookIndex` — persistent SQLite index, offline search, CLI |
+| [index.md](index.md) | `BookIndex` — persistent SQLite index, offline search, follow YouTube, CLI |
+| [cache.md](cache.md) | `audiobooker.cache` — download streams, cache to disk, play, duration filters |
 | [api.md](api.md) | Full API reference: `AudioBook`, `BookAuthor`, `AudioBookSource`, utilities |
 
 See also the `examples/` directory for runnable code:

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,119 @@
+# Cache & Download
+
+`audiobooker.cache` downloads audiobook streams to a local directory so
+subsequent plays are instant without any network access.
+
+```bash
+pip install audiobooker requests   # requests is required for downloads
+```
+
+## Cache layout
+
+```
+~/.cache/audiobooker/
+    <book_hash>/
+        meta.json          ← serialised book metadata
+        audio.mp3          ← downloaded stream file(s)
+```
+
+## Download
+
+```python
+from audiobooker.cache import download, is_cached, cached_paths
+
+book = next(iter(Librivox().search_by_title("Dracula")))
+
+download(book)              # fetch all streams → cache
+download(book, stream=0)    # first stream only
+
+if is_cached(book):
+    paths = cached_paths(book)   # list of local Path objects
+```
+
+`download()` skips files that are already in the cache — safe to call repeatedly.
+A `.part` temporary file is used during download; it is renamed on completion and
+deleted on error, so partial downloads never pollute the cache.
+
+## Play
+
+```python
+from audiobooker.cache import play
+
+play(book)           # download if needed, then open with system player
+play(book, stream=0) # specific stream index
+```
+
+`play()` uses `xdg-open` (Linux), `open` (macOS), or `os.startfile` (Windows)
+to hand the file off to the system's default audio player.
+
+## List and clear
+
+```python
+from audiobooker.cache import list_cached, clear_cache
+
+for book in list_cached():
+    print(book.title)
+
+clear_cache(book)     # remove one book
+clear_cache()         # wipe entire cache
+```
+
+## Custom cache directory
+
+```python
+from pathlib import Path
+from audiobooker.cache import download, play
+
+download(book, cache_root=Path("/data/audiobooks"))
+play(book, cache_root=Path("/data/audiobooks"))
+```
+
+## CLI
+
+```bash
+# Download by title (searches local index first, falls back to Librivox)
+python -m audiobooker.cache download "Dracula"
+python -m audiobooker.cache download "Dracula" --stream 0
+
+# Play (downloads if not cached)
+python -m audiobooker.cache play "Dracula"
+
+# Show cache info for a book
+python -m audiobooker.cache info "Dracula"
+
+# List all cached books
+python -m audiobooker.cache list
+
+# Clear entire cache
+python -m audiobooker.cache clear
+
+# Custom cache path
+python -m audiobooker.cache --cache /data/audiobooks download "Dracula"
+```
+
+## Duration filters (BookIndex)
+
+All `BookIndex.search_*` methods accept `min_duration` and `max_duration`
+parameters (in seconds) to filter by runtime:
+
+```python
+from audiobooker.index import BookIndex
+
+idx = BookIndex()
+
+# Short stories only (under 30 minutes)
+idx.search_by_tag("Horror", max_duration=1800)
+
+# Full novels (over 2 hours)
+idx.search_by_author("Dickens", min_duration=7200)
+
+# Specific range: 1–4 hours
+idx.search("Lovecraft", min_duration=3600, max_duration=14400)
+```
+
+CLI:
+
+```bash
+python -m audiobooker.index search "horror" --method search_by_tag \
+    --min-duration 3600 --max-duration 14400
+```

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -68,6 +68,31 @@ download(book, cache_root=Path("/data/audiobooks"))
 play(book, cache_root=Path("/data/audiobooks"))
 ```
 
+## Bulk download — example with TheCybrarian
+
+Download every audiobook from a YouTube channel in one pass.
+Already-cached files are skipped automatically.
+
+```python
+from audiobooker.cache import download, is_cached
+from audiobooker.scrappers.youtube import TheCybrarian
+
+for book in TheCybrarian().iterate_all():
+    if is_cached(book):
+        print(f"[cached] {book.title}")
+        continue
+    print(f"[downloading] {book.title}")
+    paths = download(book, stream=0, progress=True)
+    if paths:
+        print(f"  → {paths[0]}")
+```
+
+`TheCybrarian` ships with `title_blacklist=["update"]` so channel-update
+announcement videos are filtered out before download.
+
+See `examples/download_cybrarian.py` for the full runnable version with
+`--dry-run` and `--indexed` (index channel first, then download from index).
+
 ## CLI
 
 ```bash

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -8,8 +8,8 @@ pip install audiobooker[youtube]
 pip install tutubo
 ```
 
-When installed, `TheCybrarian` and `HorrorBabble` are automatically added to
-`ALL_SOURCES` and participate in every `search*()` call.
+When installed, `TheCybrarian`, `HorrorBabble`, and `TheDustyTome` are
+automatically added to `ALL_SOURCES` and participate in every `search*()` call.
 
 ## Pre-configured channels
 
@@ -45,6 +45,23 @@ for book in HorrorBabble().search_by_title("Lovecraft"):
 - Authors: `BookAuthor(last_name="Various")`
 - Tags: Horror, Lovecraft, Weird Fiction, Short Stories
 - `min_runtime`: 300 s (5 minutes — filters out shorts and trailers)
+
+### TheDustyTome
+
+Classic literature and fantasy audiobooks. Authors and narrators are extracted
+per-video from the title/description using `extract_metadata=True`.
+
+```python
+from audiobooker.scrappers.youtube import TheDustyTome
+
+for book in TheDustyTome().iterate_all():
+    print(book.title, book.authors)
+```
+
+- Channel: [@TheDustyTome](https://www.youtube.com/@TheDustyTome)
+- Authors: extracted per-video (falls back to empty)
+- Tags: Classic Literature, Fantasy, Audiobook
+- `min_runtime`: 300 s
 
 ## YoutubeChannelSource
 

--- a/examples/cache_usage.py
+++ b/examples/cache_usage.py
@@ -1,0 +1,93 @@
+"""Cache and download — download once, play instantly thereafter.
+
+Run:
+  python examples/cache_usage.py
+  python -m audiobooker.cache download "Dracula"
+  python -m audiobooker.cache play "Dracula"
+  python -m audiobooker.cache list
+"""
+import tempfile
+from pathlib import Path
+
+from audiobooker.base import AudioBook, BookAuthor
+from audiobooker.cache import (
+    download, is_cached, cached_paths, list_cached, clear_cache,
+)
+from audiobooker.index import BookIndex
+
+# ---------------------------------------------------------------------------
+# 1. Set up a temporary cache so this demo doesn't touch ~/.cache
+# ---------------------------------------------------------------------------
+tmp_cache = Path(tempfile.mkdtemp())
+print(f"Using temporary cache: {tmp_cache}\n")
+
+# ---------------------------------------------------------------------------
+# 2. Build a small in-memory index with one book
+# ---------------------------------------------------------------------------
+book = AudioBook(
+    title="The Call of Cthulhu",
+    authors=[BookAuthor(first_name="H. P.", last_name="Lovecraft")],
+    streams=["https://www.archive.org/download/call_of_cthulhu_0809_librivox/callofcthulhu_01_lovecraft.mp3"],
+    runtime=2640,
+    source="Librivox",
+    language="en",
+    tags=["Horror", "Weird Fiction"],
+)
+
+# ---------------------------------------------------------------------------
+# 3. Cache status before download
+# ---------------------------------------------------------------------------
+print(f"Cached before download: {is_cached(book, tmp_cache)}")
+
+# ---------------------------------------------------------------------------
+# 4. Download (uncomment to actually fetch — requires network)
+# ---------------------------------------------------------------------------
+# paths = download(book, cache_root=tmp_cache)
+# print(f"\nDownloaded to: {paths}")
+
+# ---------------------------------------------------------------------------
+# 5. Duration filters in BookIndex
+# ---------------------------------------------------------------------------
+print("\n=== Duration filters ===\n")
+
+with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+    db_path = f.name
+
+idx = BookIndex(db_path)
+
+books = [
+    AudioBook(title="Short Story", authors=[BookAuthor(last_name="A")],
+              runtime=600, streams=["http://x.com/a.mp3"], source="S"),
+    AudioBook(title="Medium Novel", authors=[BookAuthor(last_name="B")],
+              runtime=7200, streams=["http://x.com/b.mp3"], source="S"),
+    AudioBook(title="Epic Saga", authors=[BookAuthor(last_name="C")],
+              runtime=36000, streams=["http://x.com/c.mp3"], source="S"),
+]
+for b in books:
+    idx._upsert(b)
+idx._con.commit()
+idx._fts_rebuild()
+
+print("All books:")
+for b in idx.iterate_all():
+    print(f"  {b.title:20s}  {b.runtime // 60} min")
+
+print("\nOver 1 hour (min_duration=3600):")
+for b in idx.search_by_author("", min_score=0.0, max_results=0, min_duration=3600):
+    print(f"  {b.title}")
+
+print("\nUnder 2 hours (max_duration=7200):")
+for b in idx.search_by_author("", min_score=0.0, max_results=0, max_duration=7200):
+    print(f"  {b.title}")
+
+idx.close()
+
+# ---------------------------------------------------------------------------
+# 6. CLI quick-reference
+# ---------------------------------------------------------------------------
+print("\nCLI:")
+print('  python -m audiobooker.cache download "Dracula"')
+print('  python -m audiobooker.cache play "Dracula"')
+print("  python -m audiobooker.cache list")
+print("  python -m audiobooker.cache clear")
+print('  python -m audiobooker.index search "Horror" --method search_by_tag --min-duration 3600')

--- a/examples/download_cybrarian.py
+++ b/examples/download_cybrarian.py
@@ -1,0 +1,100 @@
+"""Download all audiobooks from TheCybrarian to local cache.
+
+TheCybrarian publishes Robert E. Howard audiobooks (Conan, Solomon Kane, Kull…)
+on YouTube. This script iterates the channel, skips "update" announcement videos
+(handled by title_blacklist on the source), downloads each stream to
+~/.cache/audiobooker/, and skips files already present.
+
+It also shows how to index the channel first and run the download from the index
+so book metadata is preserved across runs.
+
+Run:
+  python examples/download_cybrarian.py
+  python examples/download_cybrarian.py --dry-run    # list books without downloading
+  python examples/download_cybrarian.py --indexed     # build index first, then download
+
+Requirements:
+  pip install audiobooker[youtube]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from audiobooker.cache import download, is_cached, cached_paths, list_cached
+from audiobooker.scrappers.youtube import TheCybrarian
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List books without downloading")
+    parser.add_argument("--indexed", action="store_true",
+                        help="Index the channel first, then download from the index")
+    parser.add_argument("--cache", default=None, metavar="DIR",
+                        help="Cache directory (default ~/.cache/audiobooker)")
+    parser.add_argument("--stream", type=int, default=0,
+                        help="Stream index to download per book (default 0)")
+    args = parser.parse_args()
+
+    cache_root = Path(args.cache) if args.cache else None
+
+    if args.indexed:
+        books = _from_index()
+    else:
+        books = _from_channel()
+
+    total = skipped = downloaded = errors = 0
+
+    for book in books:
+        total += 1
+        if is_cached(book, cache_root):
+            paths = cached_paths(book, cache_root)
+            size_kb = sum(p.stat().st_size for p in paths) // 1024
+            print(f"  [cached {size_kb}KB] {book.title!r}")
+            skipped += 1
+            continue
+
+        if args.dry_run:
+            runtime_min = book.runtime // 60
+            print(f"  [would download] {book.title!r}  {runtime_min}min  {book.streams[0]}")
+            continue
+
+        print(f"  [downloading] {book.title!r}")
+        paths = download(book, stream=args.stream, cache_root=cache_root, progress=True)
+        if paths:
+            size_kb = sum(p.stat().st_size for p in paths) // 1024
+            print(f"    → {paths[0].name}  ({size_kb}KB)")
+            downloaded += 1
+        else:
+            print(f"    → ERROR: download failed")
+            errors += 1
+
+    print()
+    print(f"Total: {total}  |  Downloaded: {downloaded}  |  Already cached: {skipped}  |  Errors: {errors}")
+
+
+def _from_channel():
+    """Stream books directly from the YouTube channel."""
+    print("=== Fetching TheCybrarian channel ===\n")
+    return TheCybrarian().iterate_all()
+
+
+def _from_index():
+    """Build/update a local index, then iterate from it."""
+    from audiobooker.index import BookIndex
+
+    print("=== Indexing TheCybrarian channel ===\n")
+    idx = BookIndex()
+    added = idx.update(sources=[TheCybrarian()], progress=True)
+    print(f"  {added} new books added to index\n")
+
+    print("=== Downloading from index ===\n")
+    books = list(idx.iterate_all(source="YoutubeChannelSource"))
+    idx.close()
+    return books
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,14 @@ dependencies = [
     "rapidfuzz",
     "requests-cache",
     "site-map-parser",
+    "click>=8.0",
 ]
 
 [project.optional-dependencies]
 youtube = ["tutubo"]
+
+[project.scripts]
+audiobooker = "audiobooker.cli:cli"
 
 [project.urls]
 Homepage = "https://github.com/OpenJarbas/audiobooker"

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,0 +1,267 @@
+"""Tests for audiobooker.cache and BookIndex duration filters."""
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from audiobooker.base import AudioBook, BookAuthor
+from audiobooker.cache import (
+    is_cached, cached_paths, download, clear_cache, list_cached,
+    _book_dir, _stream_filename, _book_to_meta, _meta_to_book,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _book(title="Test Book", streams=None, runtime=3600):
+    return AudioBook(
+        title=title,
+        authors=[BookAuthor(first_name="Test", last_name="Author")],
+        streams=streams or ["http://example.com/test.mp3"],
+        runtime=runtime,
+        source="TestSource",
+    )
+
+
+BOOK = _book()
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+class TestPathHelpers(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    def test_book_dir_uses_hash(self):
+        d = _book_dir(BOOK, self.root)
+        self.assertEqual(d.parent, self.root)
+        self.assertEqual(d.name, str(hash(BOOK)))
+
+    def test_stream_filename_from_url(self):
+        name = _stream_filename("http://example.com/audio.mp3", 0)
+        self.assertEqual(name, "audio.mp3")
+
+    def test_stream_filename_fallback(self):
+        name = _stream_filename("http://example.com/stream", 2)
+        self.assertEqual(name, "stream_2.mp3")
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip
+# ---------------------------------------------------------------------------
+
+class TestSerialisation(unittest.TestCase):
+
+    def test_meta_roundtrip(self):
+        meta = _book_to_meta(BOOK)
+        book2 = _meta_to_book(meta)
+        self.assertEqual(book2.title, BOOK.title)
+        self.assertEqual(book2.streams, BOOK.streams)
+        self.assertEqual(book2.authors[0].last_name, "Author")
+
+    def test_meta_roundtrip_with_narrator(self):
+        from audiobooker.base import AudiobookNarrator
+        book = _book()
+        book.narrator = AudiobookNarrator(first_name="Wayne", last_name="June")
+        meta = _book_to_meta(book)
+        book2 = _meta_to_book(meta)
+        self.assertEqual(book2.narrator.last_name, "June")
+
+
+# ---------------------------------------------------------------------------
+# is_cached / cached_paths
+# ---------------------------------------------------------------------------
+
+class TestCacheStatus(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    def test_not_cached_initially(self):
+        self.assertFalse(is_cached(BOOK, self.root))
+
+    def test_cached_after_file_created(self):
+        d = _book_dir(BOOK, self.root)
+        d.mkdir(parents=True)
+        (d / "test.mp3").write_bytes(b"fake")
+        self.assertTrue(is_cached(BOOK, self.root))
+
+    def test_cached_paths_returns_existing(self):
+        d = _book_dir(BOOK, self.root)
+        d.mkdir(parents=True)
+        (d / "test.mp3").write_bytes(b"fake")
+        paths = cached_paths(BOOK, self.root)
+        self.assertEqual(len(paths), 1)
+        self.assertTrue(paths[0].exists())
+
+    def test_cached_paths_empty_when_nothing_downloaded(self):
+        paths = cached_paths(BOOK, self.root)
+        self.assertEqual(paths, [])
+
+
+# ---------------------------------------------------------------------------
+# download() — mocked HTTP
+# ---------------------------------------------------------------------------
+
+class TestDownload(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    def _mock_response(self, content=b"audio data"):
+        resp = MagicMock()
+        resp.headers = {"content-length": str(len(content))}
+        resp.iter_content.return_value = [content]
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    @patch("requests.get")
+    def test_download_creates_file(self, mock_get):
+        mock_get.return_value = self._mock_response()
+        paths = download(BOOK, cache_root=self.root, progress=False)
+        self.assertEqual(len(paths), 1)
+        self.assertTrue(paths[0].exists())
+        self.assertEqual(paths[0].read_bytes(), b"audio data")
+
+    @patch("requests.get")
+    def test_download_writes_meta(self, mock_get):
+        mock_get.return_value = self._mock_response()
+        download(BOOK, cache_root=self.root, progress=False)
+        meta_file = _book_dir(BOOK, self.root) / "meta.json"
+        self.assertTrue(meta_file.exists())
+
+    @patch("requests.get")
+    def test_download_skips_existing(self, mock_get):
+        mock_get.return_value = self._mock_response()
+        download(BOOK, cache_root=self.root, progress=False)
+        download(BOOK, cache_root=self.root, progress=False)
+        # Should only have been called once
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch("requests.get")
+    def test_download_stream_index(self, mock_get):
+        book = _book(streams=[
+            "http://example.com/part1.mp3",
+            "http://example.com/part2.mp3",
+        ])
+        mock_get.return_value = self._mock_response()
+        paths = download(book, stream=1, cache_root=self.root, progress=False)
+        self.assertEqual(len(paths), 1)
+        self.assertEqual(paths[0].name, "part2.mp3")
+
+    @patch("requests.get")
+    def test_download_http_error_returns_empty(self, mock_get):
+        import requests as req
+        mock_get.return_value.raise_for_status.side_effect = req.HTTPError("404")
+        mock_get.return_value.iter_content.return_value = []
+        # Should not raise — returns empty list
+        paths = download(BOOK, cache_root=self.root, progress=False)
+        self.assertEqual(paths, [])
+
+
+# ---------------------------------------------------------------------------
+# clear_cache / list_cached
+# ---------------------------------------------------------------------------
+
+class TestClearList(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+
+    @patch("requests.get")
+    def test_clear_single_book(self, mock_get):
+        resp = MagicMock()
+        resp.headers = {}
+        resp.iter_content.return_value = [b"x"]
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        download(BOOK, cache_root=self.root, progress=False)
+        self.assertTrue(is_cached(BOOK, self.root))
+        clear_cache(BOOK, self.root)
+        self.assertFalse(is_cached(BOOK, self.root))
+
+    @patch("requests.get")
+    def test_list_cached(self, mock_get):
+        resp = MagicMock()
+        resp.headers = {}
+        resp.iter_content.return_value = [b"x"]
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        download(BOOK, cache_root=self.root, progress=False)
+        books = list(list_cached(self.root))
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0].title, BOOK.title)
+
+
+# ---------------------------------------------------------------------------
+# BookIndex duration filters
+# ---------------------------------------------------------------------------
+
+class TestDurationFilter(unittest.TestCase):
+
+    def setUp(self):
+        import tempfile
+        from audiobooker.index import BookIndex
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.close()
+        self.idx = BookIndex(tmp.name)
+
+        from audiobooker.base import BookAuthor
+
+        def make(title, runtime):
+            return AudioBook(
+                title=title,
+                authors=[BookAuthor(first_name="A", last_name="B")],
+                runtime=runtime,
+                streams=["http://example.com/x.mp3"],
+                source="Test",
+            )
+
+        books = [
+            make("Short Story", 600),       # 10 min
+            make("Medium Novel", 7200),     # 2 h
+            make("Epic Saga", 36000),       # 10 h
+        ]
+        for b in books:
+            self.idx._upsert(b)
+        self.idx._con.commit()
+        self.idx._fts_rebuild()
+
+    def tearDown(self):
+        self.idx.close()
+
+    def test_min_duration_filters_short(self):
+        results = self.idx.search_by_title("story", min_score=0.0,
+                                           max_results=0, min_duration=3600)
+        self.assertFalse(any(b.title == "Short Story" for b in results))
+
+    def test_max_duration_filters_long(self):
+        results = self.idx.search_by_title("saga", min_score=0.0,
+                                           max_results=0, max_duration=10000)
+        self.assertFalse(any(b.title == "Epic Saga" for b in results))
+
+    def test_duration_range(self):
+        results = self.idx.search("novel", min_score=0.0, max_results=0,
+                                  min_duration=3600, max_duration=10000)
+        titles = {b.title for b in results}
+        self.assertIn("Medium Novel", titles)
+        self.assertNotIn("Short Story", titles)
+        self.assertNotIn("Epic Saga", titles)
+
+    def test_no_duration_filter_returns_all(self):
+        results = self.idx.search_by_author("B", min_score=0.0, max_results=0)
+        self.assertEqual(len(results), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -38,18 +38,23 @@ class TestPathHelpers(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.root = Path(self.tmp)
 
-    def test_book_dir_uses_hash(self):
+    def test_book_dir_uses_stable_id(self):
         d = _book_dir(BOOK, self.root)
         self.assertEqual(d.parent, self.root)
-        self.assertEqual(d.name, str(hash(BOOK)))
+        self.assertEqual(d.name, BOOK.stable_id())
 
     def test_stream_filename_from_url(self):
         name = _stream_filename("http://example.com/audio.mp3", 0)
-        self.assertEqual(name, "audio.mp3")
+        self.assertEqual(name, "00_audio.mp3")
+
+    def test_stream_filename_includes_index(self):
+        name1 = _stream_filename("http://example.com/audio.mp3", 0)
+        name2 = _stream_filename("http://example.com/audio.mp3", 1)
+        self.assertNotEqual(name1, name2)
 
     def test_stream_filename_fallback(self):
         name = _stream_filename("http://example.com/stream", 2)
-        self.assertEqual(name, "stream_2.mp3")
+        self.assertEqual(name, "02_stream.mp3")
 
 
 # ---------------------------------------------------------------------------
@@ -90,13 +95,15 @@ class TestCacheStatus(unittest.TestCase):
     def test_cached_after_file_created(self):
         d = _book_dir(BOOK, self.root)
         d.mkdir(parents=True)
-        (d / "test.mp3").write_bytes(b"fake")
+        fname = _stream_filename(BOOK.streams[0], 0)
+        (d / fname).write_bytes(b"fake")
         self.assertTrue(is_cached(BOOK, self.root))
 
     def test_cached_paths_returns_existing(self):
         d = _book_dir(BOOK, self.root)
         d.mkdir(parents=True)
-        (d / "test.mp3").write_bytes(b"fake")
+        fname = _stream_filename(BOOK.streams[0], 0)
+        (d / fname).write_bytes(b"fake")
         paths = cached_paths(BOOK, self.root)
         self.assertEqual(len(paths), 1)
         self.assertTrue(paths[0].exists())
@@ -155,7 +162,7 @@ class TestDownload(unittest.TestCase):
         mock_get.return_value = self._mock_response()
         paths = download(book, stream=1, cache_root=self.root, progress=False)
         self.assertEqual(len(paths), 1)
-        self.assertEqual(paths[0].name, "part2.mp3")
+        self.assertEqual(paths[0].name, "01_part2.mp3")
 
     @patch("requests.get")
     def test_download_http_error_returns_empty(self, mock_get):


### PR DESCRIPTION
## Summary

- **Click CLI** — \`audiobooker\` entry point with three command groups:
  - \`audiobooker search <query>\` — live search across web sources
  - \`audiobooker index build/update/stats/search/follow/unfollow/list\` — full index management
  - \`audiobooker cache download/play/list/clear/info\` — local file cache management
  - Shared options: \`--source\`, \`--language\`, \`--min-duration\`, \`--max-duration\`, \`--verbose\`
  - \`click>=8.0\` added to dependencies; registered as \`audiobooker\` entry point in \`pyproject.toml\`

- **Local cache** (\`audiobooker.cache\`) — download streams to \`~/.cache/audiobooker/<stable_id>/\` once, serve locally on repeat plays
  - \`download()\`, \`play()\`, \`is_cached()\`, \`cached_paths()\`, \`list_cached()\`, \`clear_cache()\`
  - \`.part\` temp file prevents partial downloads polluting the cache
  - Book lookup hits local \`BookIndex\` first, falls back to live Librivox

- **Stable cache/index key** — \`AudioBook.stable_id()\` uses SHA-256 over title+authors, stable across processes (fixes PYTHONHASHSEED non-determinism); stream filenames prefixed with index to eliminate basename collisions

- **Duration filters** — \`min_duration\` / \`max_duration\` on all \`BookIndex.search_*()\` methods and CLI

- **Per-video tags** — when \`extract_metadata=True\`, per-video hashtags take priority; channel-level tags only used as fallback when a video has no hashtags

- **TheDustyTome** — new \`YoutubeChannelSource\` for \`@TheDustyTome/videos\`, authors/narrator extracted per-video

- **Examples**: \`examples/cache_usage.py\`, \`examples/download_cybrarian.py\` (\`--dry-run\`, \`--indexed\` flags)

## Test plan

- [ ] \`uv run pytest test/\` — 115 tests, all passing
- [ ] \`pip install -e .\` then \`audiobooker --help\` shows top-level commands
- [ ] \`audiobooker index build --sources audioanarchy\` completes
- [ ] \`audiobooker index search "Lovecraft"\` returns results
- [ ] \`audiobooker cache download "Dracula"\` downloads to \`~/.cache/audiobooker/\`
- [ ] Re-running download skips existing files
- [ ] \`audiobooker cache list\` shows the cached book
- [ ] \`audiobooker index search "horror" --method search_by_tag --min-duration 3600\` excludes short tracks
- [ ] \`python examples/download_cybrarian.py --dry-run\` lists books without downloading

## CodeRabbit fixes

- **Major**: \`hash(book)\` replaced with \`AudioBook.stable_id()\` (SHA-256, PYTHONHASHSEED-safe) — cache dirs and DB keys now survive process restarts
- **Major**: \`_stream_filename()\` now prefixes every file with a zero-padded index (\`00_audio.mp3\`) — eliminates overwrites when streams share a basename

## AI Usage Disclaimer

claude-sonnet-4-6. Human reviewed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)