### PR TITLE
feat: route HTTP through unblock_requests CloudflareSession via soft-import

### DIFF
--- a/audiobooker/transport.py
+++ b/audiobooker/transport.py
@@ -23,10 +23,13 @@ from audiobooker.utils import random_user_agent
 def default_session():
     """Return the default HTTP session for audiobooker scrapers.
 
-    Returns a ``curl_cffi.requests.Session`` if
-    ``AUDIOBOOKER_TRANSPORT=curl_cffi`` is set in the environment AND
-    ``curl_cffi`` is importable. Otherwise returns a standard
-    ``requests.Session`` with a randomized User-Agent header.
+    When ``AUDIOBOOKER_TRANSPORT=curl_cffi`` is set in the environment AND
+    ``curl_cffi`` is importable, returns a ``curl_cffi.requests.Session``.
+    Otherwise prefers an ``unblock_requests.CloudflareSession`` when that
+    optional dependency (``[stealth]`` extra) is importable, transparently
+    routing requests through anti-bot bypass with a Wayback Machine
+    fallback. If neither is available, returns a standard
+    ``requests.Session``. All sessions carry a randomized User-Agent header.
     """
     if os.environ.get("AUDIOBOOKER_TRANSPORT") == "curl_cffi":
         try:
@@ -39,6 +42,14 @@ def default_session():
             return session
         except ImportError:
             pass
+    try:
+        from unblock_requests import CloudflareSession
+        session = CloudflareSession(env_prefix="AUDIOBOOKER",
+                                    wayback_fallback=True)
+        session.headers.update({"User-Agent": random_user_agent()})
+        return session
+    except Exception:
+        pass
     session = requests.Session()
     session.headers.update({"User-Agent": random_user_agent()})
     return session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest", "vcrpy", "pytest-vcr"]
 youtube = ["tutubo"]
-stealth = ["curl-cffi"]
+stealth = ["curl-cffi", "unblock_requests"]
 
 [project.scripts]
 audiobooker = "audiobooker.cli:cli"


### PR DESCRIPTION
Routes audiobooker's shared HTTP transport through `unblock_requests.CloudflareSession` via a non-breaking soft-import.

## What

`audiobooker/transport.py` has a single session-creation site, `default_session()`, shared by every scraper backend. The selection order is now:

1. `AUDIOBOOKER_TRANSPORT=curl_cffi` + importable `curl_cffi` -> curl_cffi session (existing explicit opt-in, unchanged)
2. importable `unblock_requests` -> `CloudflareSession(env_prefix="AUDIOBOOKER", wayback_fallback=True)` (new, anti-bot bypass with Wayback fallback)
3. plain `requests.Session` (existing default)

The new step is guarded by `try/except Exception`, so when `unblock_requests` is not installed behavior is identical to before. The randomized User-Agent header is re-applied on the new session. `CloudflareSession` subclasses `requests.Session`, so the public API, parse layer, and the injectable-session contract are unchanged.

## Packaging

`unblock_requests` appended to the optional `[stealth]` extra. Not a core dependency.

## Verification

- `py_compile` clean
- `pytest -q -p no:ovoscope -p no:recording`: 323 passed, 1 skipped. The 3 `test_converters` failures are pre-existing on `dev` (unrelated mediavocab taxonomy issue), not introduced here.